### PR TITLE
Fix boolean checks and remove circular import

### DIFF
--- a/burstGen.py
+++ b/burstGen.py
@@ -33,7 +33,7 @@ def sizeof_fmt(num, suffix='B'):
 # SB_FAILCOUNT 	integer, 	Current send fail count
 # SB_MESSAGE	string, 	Message string to send
 def sendmail(number, burst, SB_FAILCOUNT, SB_MESSAGE):
-	if SB_FAILCOUNT.value >= SB_STOPFQNT && SB_STOPFAIL == True :
+	if SB_FAILCOUNT.value >= SB_STOPFQNT and SB_STOPFAIL == True :
 		pass
 
 	print("%s/%s, Burst %s : Sending Email" % (number, SB_TOTAL, burst))

--- a/burstMain.py
+++ b/burstMain.py
@@ -21,10 +21,10 @@ if __name__ == '__main__':
 		quantity = range(1, SB_SGEMAILS + 1)
 		procs = []
 		
-		if SB_FAILCOUNT.value >= SB_STOPFQNT && SB_STOPFAIL == True :
+		if SB_FAILCOUNT.value >= SB_STOPFQNT and SB_STOPFAIL == True :
 			break
 		for index, number in enumerate(quantity):
-			if SB_FAILCOUNT.value >= SB_STOPFQNT && SB_STOPFAIL == True :
+			if SB_FAILCOUNT.value >= SB_STOPFQNT and SB_STOPFAIL == True :
 				break
 			time.sleep(SB_SGEMAILSPSEC)
 			process = Process(target=sendmail, args=(number + (x * SB_SGEMAILS), x + 1, SB_FAILCOUNT, SB_MESSAGE))

--- a/burstVars.py
+++ b/burstVars.py
@@ -1,4 +1,8 @@
-from burstGen import *
+# Size constants
+SZ_KILOBYTE = 1024
+SZ_MEGABYTE = 1024 * SZ_KILOBYTE
+SZ_GIGABYTE = 1024 * SZ_MEGABYTE
+SZ_TERABYTE = 1024 * SZ_GIGABYTE
 
 #SB_SGEMAILS		integer, Emails per segment
 #SB_SGEMAILSPSEC	integer, Time between emails


### PR DESCRIPTION
## Summary
- fix incorrect `&&` boolean operators
- remove circular import by defining size constants in `burstVars.py`
- keep indentation consistent

## Testing
- `python -m py_compile burstMain.py burstGen.py burstVars.py`

------
https://chatgpt.com/codex/tasks/task_e_685557453f5c8325a3785fb71d201982