### PR TITLE
Fix typo in comment

### DIFF
--- a/burstGen.py
+++ b/burstGen.py
@@ -17,7 +17,7 @@ def genData(size):
 def appendMessage() :
 	return (SB_MESSAGEC + genData(SB_SIZE)).encode('ascii', 'ignore')
 
-# Get human reable size from sizeof
+# Get human readable size from sizeof
 # num 		integer, size in bytes
 # suffix 	integer, suffix to append
 def sizeof_fmt(num, suffix='B'):


### PR DESCRIPTION
## Summary
- fix typo in `burstGen` comment

## Testing
- `python -m py_compile burstGen.py burstMain.py burstVars.py` *(fails: SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_685557b9d95c832589689d04d649f7cf