### PR TITLE
Fix stop condition logic

### DIFF
--- a/burstGen.py
+++ b/burstGen.py
@@ -33,7 +33,7 @@ def sizeof_fmt(num, suffix='B'):
 # SB_FAILCOUNT 	integer, 	Current send fail count
 # SB_MESSAGE	string, 	Message string to send
 def sendmail(number, burst, SB_FAILCOUNT, SB_MESSAGE):
-	if SB_FAILCOUNT.value >= SB_STOPFQNT && SB_STOPFAIL == True :
+	if SB_FAILCOUNT.value >= SB_STOPFQNT and SB_STOPFAIL:
 		pass
 
 	print("%s/%s, Burst %s : Sending Email" % (number, SB_TOTAL, burst))

--- a/burstMain.py
+++ b/burstMain.py
@@ -21,10 +21,10 @@ if __name__ == '__main__':
 		quantity = range(1, SB_SGEMAILS + 1)
 		procs = []
 		
-		if SB_FAILCOUNT.value >= SB_STOPFQNT && SB_STOPFAIL == True :
+		if SB_FAILCOUNT.value >= SB_STOPFQNT and SB_STOPFAIL:
 			break
 		for index, number in enumerate(quantity):
-			if SB_FAILCOUNT.value >= SB_STOPFQNT && SB_STOPFAIL == True :
+			if SB_FAILCOUNT.value >= SB_STOPFQNT and SB_STOPFAIL:
 				break
 			time.sleep(SB_SGEMAILSPSEC)
 			process = Process(target=sendmail, args=(number + (x * SB_SGEMAILS), x + 1, SB_FAILCOUNT, SB_MESSAGE))


### PR DESCRIPTION
## Summary
- use Python's `and` in the stop condition logic

## Testing
- `python -m py_compile burstGen.py burstMain.py`


------
https://chatgpt.com/codex/tasks/task_e_6855589296348325a1e09e5430cefc71