### PR TITLE
Fix comment for suffix parameter

### DIFF
--- a/burstGen.py
+++ b/burstGen.py
@@ -19,7 +19,7 @@ def appendMessage() :
 
 # Get human readable size from sizeof
 # num 		integer, size in bytes
-# suffix 	integer, suffix to append
+# suffix        string, suffix to append
 def sizeof_fmt(num, suffix='B'):
     for unit in ['','Ki','Mi','Gi','Ti','Pi','Ei','Zi']:
         if abs(num) < 1024.0:


### PR DESCRIPTION
## Summary
- clarify documentation in `sizeof_fmt` that suffix is a string

## Testing
- `python -m py_compile burstGen.py burstMain.py burstVars.py`

------
https://chatgpt.com/codex/tasks/task_e_68555c86a8048325b5b91e13a97c41cf