### PR TITLE
Fix license attribution

### DIFF
--- a/license.md
+++ b/license.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Eduardo Mota
+Copyright (c) 2019 supermarsx
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- update MIT license to attribute `supermarsx`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68556f8baed48325ac7406710ee0242c