### PR TITLE
Fix early exit of sendmail and add coverage

### DIFF
--- a/burstGen.py
+++ b/burstGen.py
@@ -34,7 +34,7 @@ def sizeof_fmt(num, suffix='B'):
 # SB_MESSAGE	string, 	Message string to send
 def sendmail(number, burst, SB_FAILCOUNT, SB_MESSAGE):
 	if SB_FAILCOUNT.value >= SB_STOPFQNT and SB_STOPFAIL == True :
-		pass
+		return
 
 	print("%s/%s, Burst %s : Sending Email" % (number, SB_TOTAL, burst))
 	try:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,10 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from burstGen import sizeof_fmt
+from burstGen import sendmail
+import burstGen
+import burstVars
+from unittest.mock import MagicMock
 
 
 def test_sizeof_fmt_1kib():
@@ -14,3 +18,20 @@ def test_sizeof_fmt_1kib():
 
 def test_sizeof_fmt_1_5kib():
     assert sizeof_fmt(1536) == "1.5KiB"
+
+
+def test_sendmail_exits_when_failcount_exceeded(monkeypatch):
+    """sendmail should not create an SMTP object once failure threshold hit."""
+
+    class DummyCounter:
+        def __init__(self, value):
+            self.value = value
+
+    fail_counter = DummyCounter(burstVars.SB_STOPFQNT)
+
+    smtp_mock = MagicMock()
+    monkeypatch.setattr(burstGen.smtplib, "SMTP", smtp_mock)
+
+    sendmail(1, 1, fail_counter, b"msg")
+
+    assert not smtp_mock.called


### PR DESCRIPTION
## Summary
- exit early in `burstGen.sendmail` when stop threshold reached
- add tests for early-exit behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad5557cbc8325abd691216d06a65c