### PR TITLE
Update SMTP connection with context manager

### DIFF
--- a/burstGen.py
+++ b/burstGen.py
@@ -33,23 +33,23 @@ def sizeof_fmt(num, suffix='B'):
 # SB_FAILCOUNT 	integer, 	Current send fail count
 # SB_MESSAGE	string, 	Message string to send
 def sendmail(number, burst, SB_FAILCOUNT, SB_MESSAGE):
-	if SB_FAILCOUNT.value >= SB_STOPFQNT and SB_STOPFAIL == True :
-		pass
+    if SB_FAILCOUNT.value >= SB_STOPFQNT and SB_STOPFAIL == True:
+        pass
 
-	print("%s/%s, Burst %s : Sending Email" % (number, SB_TOTAL, burst))
-	try:
-	   smtpObj = smtplib.SMTP(SB_SERVER)
-	   smtpObj.sendmail(SB_SENDER, SB_RECEIVERS, SB_MESSAGE)         
-	   print("%s/%s, Burst %s : Email Sent" % (number, SB_TOTAL, burst))
-	except SMTPException:
-		SB_FAILCOUNT.value += 1
-		print("%s/%s, Burst %s/%s : Failure %s/%s, Unable to send email" % (number, SB_TOTAL, burst, SB_BURSTS, SB_FAILCOUNT.value, SB_STOPFQNT))
-	except SMTPSenderRefused:
-		SB_FAILCOUNT.value += 1
-		print("%s/%s, Burst %s : Failure %s/%s, Sender refused" % (number, SB_TOTAL, burst, SB_BURSTS, SB_FAILCOUNT.value, SB_STOPFQNT))
-	except SMTPRecipientsRefused:
-		SB_FAILCOUNT.value += 1
-		print("%s/%s, Burst %s : Failure %s/%s, Recipients refused" % (number, SB_TOTAL, burst, SB_BURSTS, SB_FAILCOUNT.value, SB_STOPFQNT))
-	except SMTPDataError:
-		SB_FAILCOUNT.value += 1
-		print("%s/%s, Burst %s : Failure %s/%s, Data Error" % (number, SB_TOTAL, burst, SB_BURSTS, SB_FAILCOUNT.value, SB_STOPFQNT))
+    print("%s/%s, Burst %s : Sending Email" % (number, SB_TOTAL, burst))
+    try:
+        with smtplib.SMTP(SB_SERVER) as smtpObj:
+            smtpObj.sendmail(SB_SENDER, SB_RECEIVERS, SB_MESSAGE)
+        print("%s/%s, Burst %s : Email Sent" % (number, SB_TOTAL, burst))
+    except SMTPException:
+        SB_FAILCOUNT.value += 1
+        print("%s/%s, Burst %s/%s : Failure %s/%s, Unable to send email" % (number, SB_TOTAL, burst, SB_BURSTS, SB_FAILCOUNT.value, SB_STOPFQNT))
+    except SMTPSenderRefused:
+        SB_FAILCOUNT.value += 1
+        print("%s/%s, Burst %s : Failure %s/%s, Sender refused" % (number, SB_TOTAL, burst, SB_BURSTS, SB_FAILCOUNT.value, SB_STOPFQNT))
+    except SMTPRecipientsRefused:
+        SB_FAILCOUNT.value += 1
+        print("%s/%s, Burst %s : Failure %s/%s, Recipients refused" % (number, SB_TOTAL, burst, SB_BURSTS, SB_FAILCOUNT.value, SB_STOPFQNT))
+    except SMTPDataError:
+        SB_FAILCOUNT.value += 1
+        print("%s/%s, Burst %s : Failure %s/%s, Data Error" % (number, SB_TOTAL, burst, SB_BURSTS, SB_FAILCOUNT.value, SB_STOPFQNT))


### PR DESCRIPTION
## Summary
- refactor `burstGen.sendmail` to use `with smtplib.SMTP()`
- keep indentation consistent to avoid TabError

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad55886f88325bad97eb34ba64a7f