### PR TITLE
Remove duplicate SZ constants

### DIFF
--- a/burstGen.py
+++ b/burstGen.py
@@ -2,12 +2,6 @@ import random, smtplib
 from smtplib import *
 from burstVars import *
 
-# Size constants
-SZ_KILOBYTE = 1024
-SZ_MEGABYTE = 1024 * SZ_KILOBYTE
-SZ_GIGABYTE = 1024 * SZ_MEGABYTE
-SZ_TERABYTE = 1024 * SZ_GIGABYTE
-
 # Generate random data
 # size 		integer, size in bytes
 def genData(size):


### PR DESCRIPTION
## Summary
- deduplicate `SZ_*` constants by keeping them only in `burstVars.py`
- rely on `burstVars` import in `burstGen`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad56f982483259bb36bc1f64df559