### PR TITLE
Fix burstGen error formatting

### DIFF
--- a/burstGen.py
+++ b/burstGen.py
@@ -46,10 +46,10 @@ def sendmail(number, burst, SB_FAILCOUNT, SB_MESSAGE):
 		print("%s/%s, Burst %s/%s : Failure %s/%s, Unable to send email" % (number, SB_TOTAL, burst, SB_BURSTS, SB_FAILCOUNT.value, SB_STOPFQNT))
 	except SMTPSenderRefused:
 		SB_FAILCOUNT.value += 1
-		print("%s/%s, Burst %s : Failure %s/%s, Sender refused" % (number, SB_TOTAL, burst, SB_BURSTS, SB_FAILCOUNT.value, SB_STOPFQNT))
+		print("%s/%s, Burst %s/%s : Failure %s/%s, Sender refused" % (number, SB_TOTAL, burst, SB_BURSTS, SB_FAILCOUNT.value, SB_STOPFQNT))
 	except SMTPRecipientsRefused:
 		SB_FAILCOUNT.value += 1
-		print("%s/%s, Burst %s : Failure %s/%s, Recipients refused" % (number, SB_TOTAL, burst, SB_BURSTS, SB_FAILCOUNT.value, SB_STOPFQNT))
+		print("%s/%s, Burst %s/%s : Failure %s/%s, Recipients refused" % (number, SB_TOTAL, burst, SB_BURSTS, SB_FAILCOUNT.value, SB_STOPFQNT))
 	except SMTPDataError:
 		SB_FAILCOUNT.value += 1
-		print("%s/%s, Burst %s : Failure %s/%s, Data Error" % (number, SB_TOTAL, burst, SB_BURSTS, SB_FAILCOUNT.value, SB_STOPFQNT))
+		print("%s/%s, Burst %s/%s : Failure %s/%s, Data Error" % (number, SB_TOTAL, burst, SB_BURSTS, SB_FAILCOUNT.value, SB_STOPFQNT))


### PR DESCRIPTION
## Summary
- show burst total when sending error messages
- fix placeholder counts in SMTPSenderRefused, SMTPRecipientsRefused, and SMTPDataError branches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad57b237c8325bb806d1b0e087242