### PR TITLE
Add argparse CLI for smtp-burst

### DIFF
--- a/burstGen.py
+++ b/burstGen.py
@@ -3,16 +3,16 @@ from smtplib import *
 from burstVars import *
 
 # Generate random data
-# size 		integer, size in bytes
+# size      integer, size in bytes
 def genData(size):
-	return bytearray(random.getrandbits(8) for i in range(size)).decode("utf-8", "ignore")
+    return bytearray(random.getrandbits(8) for i in range(size)).decode("utf-8", "ignore")
 
 # Append message with generated data
 def appendMessage() :
-	return (SB_MESSAGEC + genData(SB_SIZE)).encode('ascii', 'ignore')
+    return (SB_MESSAGEC + genData(SB_SIZE)).encode('ascii', 'ignore')
 
 # Get human readable size from sizeof
-# num 		integer, size in bytes
+# num       integer, size in bytes
 # suffix        string, suffix to append
 def sizeof_fmt(num, suffix='B'):
     for unit in ['','Ki','Mi','Gi','Ti','Pi','Ei','Zi']:
@@ -20,15 +20,15 @@ def sizeof_fmt(num, suffix='B'):
             return "%3.1f%s%s" % (num, unit, suffix)
         num /= 1024.0
     return "%.1f%s%s" % (num, 'Yi', suffix)
-	
+    
 # Send email
-# number 		integer, 	Email number
-# burst			integer, 	Burst round
-# SB_FAILCOUNT 	integer, 	Current send fail count
-# SB_MESSAGE	string, 	Message string to send
+# number        integer,    Email number
+# burst         integer,    Burst round
+# SB_FAILCOUNT  integer,    Current send fail count
+# SB_MESSAGE    string,     Message string to send
 def sendmail(number, burst, SB_FAILCOUNT, SB_MESSAGE):
-	if SB_FAILCOUNT.value >= SB_STOPFQNT and SB_STOPFAIL == True :
-		return
+    if SB_FAILCOUNT.value >= SB_STOPFQNT and SB_STOPFAIL == True :
+        return
 
     print("%s/%s, Burst %s : Sending Email" % (number, SB_TOTAL, burst))
     try:

--- a/burstMain.py
+++ b/burstMain.py
@@ -2,38 +2,56 @@ import time
 import sys
 from multiprocessing import Process, Manager
 
-from burstVars import *
-from burstGen import *
+import burstVars
+import burstGen
+import burst_cli
 
 # Main script routine
 if __name__ == '__main__':
+    args = burst_cli.parse_args()
 
-	print("Starting smtp-burst")
-	manager = Manager()
-	SB_FAILCOUNT = manager.Value('i', 0)
-	
-	print("Generating %s of data to append to message" % (sizeof_fmt(SB_SIZE)))
-	SB_MESSAGE = appendMessage()
-	print("Message using %s of random data" % (sizeof_fmt(sys.getsizeof(SB_MESSAGE))))
-	
-	print("Sending %s messages from %s to %s through %s" % (SB_TOTAL, SB_SENDER, SB_RECEIVERS, SB_SERVER))
-	
-	for x in range(0, SB_BURSTS):
-		quantity = range(1, SB_SGEMAILS + 1)
-		procs = []
-		
+    burstVars.SB_SERVER = args.server
+    burstVars.SB_SENDER = args.sender
+    burstVars.SB_RECEIVERS = args.receivers
+    burstVars.SB_SGEMAILS = args.emails_per_burst
+    burstVars.SB_BURSTS = args.bursts
+    burstVars.SB_SGEMAILSPSEC = args.email_delay
+    burstVars.SB_BURSTSPSEC = args.burst_delay
+    burstVars.SB_SIZE = args.size
+    burstVars.SB_STOPFAIL = args.stop_on_fail
+    burstVars.SB_STOPFQNT = args.stop_fail_count
+    burstVars.SB_TOTAL = burstVars.SB_SGEMAILS * burstVars.SB_BURSTS
 
-		if SB_FAILCOUNT.value >= SB_STOPFQNT and SB_STOPFAIL == True :
-			break
-		for index, number in enumerate(quantity):
-			if SB_FAILCOUNT.value >= SB_STOPFQNT and SB_STOPFAIL == True :
-				break
-			time.sleep(SB_SGEMAILSPSEC)
-			process = Process(target=sendmail, args=(number + (x * SB_SGEMAILS), x + 1, SB_FAILCOUNT, SB_MESSAGE))
-			procs.append(process)
-			process.start()
-			
-	 
-		for process in procs:
-			process.join()
-		time.sleep(SB_BURSTSPSEC)
+    print("Starting smtp-burst")
+    manager = Manager()
+    SB_FAILCOUNT = manager.Value('i', 0)
+
+    print("Generating %s of data to append to message" % (burstGen.sizeof_fmt(burstVars.SB_SIZE)))
+    SB_MESSAGE = burstGen.appendMessage()
+    print("Message using %s of random data" % (burstGen.sizeof_fmt(sys.getsizeof(SB_MESSAGE))))
+
+    print(
+        "Sending %s messages from %s to %s through %s"
+        % (burstVars.SB_TOTAL, burstVars.SB_SENDER, burstVars.SB_RECEIVERS, burstVars.SB_SERVER)
+    )
+
+    for x in range(0, burstVars.SB_BURSTS):
+        quantity = range(1, burstVars.SB_SGEMAILS + 1)
+        procs = []
+
+        if SB_FAILCOUNT.value >= burstVars.SB_STOPFQNT and burstVars.SB_STOPFAIL:
+            break
+        for index, number in enumerate(quantity):
+            if SB_FAILCOUNT.value >= burstVars.SB_STOPFQNT and burstVars.SB_STOPFAIL:
+                break
+            time.sleep(burstVars.SB_SGEMAILSPSEC)
+            process = Process(
+                target=burstGen.sendmail,
+                args=(number + (x * burstVars.SB_SGEMAILS), x + 1, SB_FAILCOUNT, SB_MESSAGE),
+            )
+            procs.append(process)
+            process.start()
+
+        for process in procs:
+            process.join()
+        time.sleep(burstVars.SB_BURSTSPSEC)

--- a/burst_cli.py
+++ b/burst_cli.py
@@ -1,0 +1,74 @@
+import argparse
+import burstVars
+
+
+def build_parser():
+    """Return argument parser for smtp-burst."""
+    parser = argparse.ArgumentParser(
+        description="Send bursts of SMTP emails for testing purposes"    )
+    parser.add_argument(
+        "--server",
+        default=burstVars.SB_SERVER,
+        help="SMTP server to connect to",
+    )
+    parser.add_argument(
+        "--sender",
+        default=burstVars.SB_SENDER,
+        help="Envelope sender address",
+    )
+    parser.add_argument(
+        "--receivers",
+        nargs="+",
+        default=burstVars.SB_RECEIVERS,
+        help="Space separated list of recipient addresses",
+    )
+    parser.add_argument(
+        "--emails-per-burst",
+        type=int,
+        default=burstVars.SB_SGEMAILS,
+        help="Number of emails per burst",
+    )
+    parser.add_argument(
+        "--bursts",
+        type=int,
+        default=burstVars.SB_BURSTS,
+        help="Number of bursts to send",
+    )
+    parser.add_argument(
+        "--email-delay",
+        type=float,
+        default=burstVars.SB_SGEMAILSPSEC,
+        help="Delay in seconds between individual emails",
+    )
+    parser.add_argument(
+        "--burst-delay",
+        type=float,
+        default=burstVars.SB_BURSTSPSEC,
+        help="Delay in seconds between bursts",
+    )
+    parser.add_argument(
+        "--size",
+        type=int,
+        default=burstVars.SB_SIZE,
+        help="Random data size in bytes appended to each message",
+    )
+    parser.add_argument(
+        "--stop-on-fail",
+        action="store_true",
+        default=burstVars.SB_STOPFAIL,
+        help="Stop execution when --stop-fail-count failures occur",
+    )
+    parser.add_argument(
+        "--stop-fail-count",
+        type=int,
+        default=burstVars.SB_STOPFQNT,
+        help="Number of failed emails that triggers stopping",
+    )
+    return parser
+
+
+def parse_args(args=None):
+    """Parse command line arguments."""
+    parser = build_parser()
+    return parser.parse_args(args)
+

--- a/readme.md
+++ b/readme.md
@@ -3,12 +3,16 @@ Simple python script that sends smtp email in bursts using independent processes
 
 ## Quick Start
 
-1. Edit `burstVars.py` as needed for your tests.
-  2. Start testing by executing `burstMain.py` from the command line.
+1. Edit `burstVars.py` as needed for your tests or override values on the
+   command line.
+2. Start testing by executing `burstMain.py` with optional CLI flags.
 
-     ```
-     $ python ./burstMain.py
-     ```
+   ```bash
+   $ python ./burstMain.py --server smtp.example.com \
+       --sender from@example.com --receivers to@example.com other@example.com
+   ```
+
+   Use `-h`/`--help` to see all available options.
 
 ## Running Tests
 


### PR DESCRIPTION
## Summary
- add `burst_cli.py` module to expose argparse options
- integrate new CLI into `burstMain.py`
- convert tabs to spaces in `burstGen.py`
- document CLI usage in the README

## Testing
- `pytest -q`
- `python burstMain.py --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_685adbe3586c8325b22bed05e8059e93