### PR TITLE
Add idle socket mode

### DIFF
--- a/burstGen.py
+++ b/burstGen.py
@@ -3,16 +3,16 @@ from smtplib import *
 from burstVars import *
 
 # Generate random data
-# size 		integer, size in bytes
+# size      integer, size in bytes
 def genData(size):
-	return bytearray(random.getrandbits(8) for i in range(size)).decode("utf-8", "ignore")
+    return bytearray(random.getrandbits(8) for i in range(size)).decode("utf-8", "ignore")
 
 # Append message with generated data
 def appendMessage() :
-	return (SB_MESSAGEC + genData(SB_SIZE)).encode('ascii', 'ignore')
+    return (SB_MESSAGEC + genData(SB_SIZE)).encode('ascii', 'ignore')
 
 # Get human readable size from sizeof
-# num 		integer, size in bytes
+# num       integer, size in bytes
 # suffix        string, suffix to append
 def sizeof_fmt(num, suffix='B'):
     for unit in ['','Ki','Mi','Gi','Ti','Pi','Ei','Zi']:
@@ -20,15 +20,15 @@ def sizeof_fmt(num, suffix='B'):
             return "%3.1f%s%s" % (num, unit, suffix)
         num /= 1024.0
     return "%.1f%s%s" % (num, 'Yi', suffix)
-	
+    
 # Send email
-# number 		integer, 	Email number
-# burst			integer, 	Burst round
-# SB_FAILCOUNT 	integer, 	Current send fail count
-# SB_MESSAGE	string, 	Message string to send
+# number        integer,    Email number
+# burst         integer,    Burst round
+# SB_FAILCOUNT  integer,    Current send fail count
+# SB_MESSAGE    string,     Message string to send
 def sendmail(number, burst, SB_FAILCOUNT, SB_MESSAGE):
-	if SB_FAILCOUNT.value >= SB_STOPFQNT and SB_STOPFAIL == True :
-		return
+    if SB_FAILCOUNT.value >= SB_STOPFQNT and SB_STOPFAIL == True :
+        return
 
     print("%s/%s, Burst %s : Sending Email" % (number, SB_TOTAL, burst))
     try:

--- a/burstMain.py
+++ b/burstMain.py
@@ -1,39 +1,88 @@
 import time
 import sys
+import argparse
+import socket
+import signal
 from multiprocessing import Process, Manager
 
 from burstVars import *
 from burstGen import *
 
-# Main script routine
+
+def burst_sendmails():
+    print("Starting smtp-burst")
+    manager = Manager()
+    SB_FAILCOUNT = manager.Value('i', 0)
+
+    print("Generating %s of data to append to message" % (sizeof_fmt(SB_SIZE)))
+    SB_MESSAGE = appendMessage()
+    print("Message using %s of random data" % (sizeof_fmt(sys.getsizeof(SB_MESSAGE))))
+
+    print("Sending %s messages from %s to %s through %s" % (SB_TOTAL, SB_SENDER, SB_RECEIVERS, SB_SERVER))
+
+    for x in range(0, SB_BURSTS):
+        quantity = range(1, SB_SGEMAILS + 1)
+        procs = []
+
+        if SB_FAILCOUNT.value >= SB_STOPFQNT and SB_STOPFAIL == True :
+            break
+        for index, number in enumerate(quantity):
+            if SB_FAILCOUNT.value >= SB_STOPFQNT and SB_STOPFAIL == True :
+                break
+            time.sleep(SB_SGEMAILSPSEC)
+            process = Process(target=sendmail, args=(number + (x * SB_SGEMAILS), x + 1, SB_FAILCOUNT, SB_MESSAGE))
+            procs.append(process)
+            process.start()
+
+        for process in procs:
+            process.join()
+        time.sleep(SB_BURSTSPSEC)
+
+
+def idle_socket_mode(duration):
+    host = SB_SERVER
+    port = 25
+    if ':' in host:
+        host, port_str = host.split(':', 1)
+        port = int(port_str)
+
+    sockets = []
+
+    def cleanup(signum=None, frame=None):
+        print("Closing %s sockets" % len(sockets))
+        for s in sockets:
+            try:
+                s.close()
+            except Exception:
+                pass
+        sockets.clear()
+
+    signal.signal(signal.SIGINT, lambda s, f: (cleanup(), sys.exit(0)))
+    signal.signal(signal.SIGTERM, lambda s, f: (cleanup(), sys.exit(0)))
+
+    end = time.time() + duration
+    while time.time() < end:
+        try:
+            s = socket.create_connection((host, port))
+            sockets.append(s)
+        except Exception as e:
+            print("Socket error: %s" % e)
+        time.sleep(0.1)
+
+    cleanup()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="smtp-burst")
+    parser.add_argument('--idle-sockets', action='store_true', help='Open idle TCP sockets to the SMTP server')
+    parser.add_argument('--duration', type=int, default=30, help='Duration to keep idle sockets open (seconds)')
+    args = parser.parse_args()
+
+    if args.idle_sockets:
+        idle_socket_mode(args.duration)
+    else:
+        burst_sendmails()
+
+
 if __name__ == '__main__':
-
-	print("Starting smtp-burst")
-	manager = Manager()
-	SB_FAILCOUNT = manager.Value('i', 0)
-	
-	print("Generating %s of data to append to message" % (sizeof_fmt(SB_SIZE)))
-	SB_MESSAGE = appendMessage()
-	print("Message using %s of random data" % (sizeof_fmt(sys.getsizeof(SB_MESSAGE))))
-	
-	print("Sending %s messages from %s to %s through %s" % (SB_TOTAL, SB_SENDER, SB_RECEIVERS, SB_SERVER))
-	
-	for x in range(0, SB_BURSTS):
-		quantity = range(1, SB_SGEMAILS + 1)
-		procs = []
-		
-
-		if SB_FAILCOUNT.value >= SB_STOPFQNT and SB_STOPFAIL == True :
-			break
-		for index, number in enumerate(quantity):
-			if SB_FAILCOUNT.value >= SB_STOPFQNT and SB_STOPFAIL == True :
-				break
-			time.sleep(SB_SGEMAILSPSEC)
-			process = Process(target=sendmail, args=(number + (x * SB_SGEMAILS), x + 1, SB_FAILCOUNT, SB_MESSAGE))
-			procs.append(process)
-			process.start()
-			
-	 
-		for process in procs:
-			process.join()
-		time.sleep(SB_BURSTSPSEC)
+    main()

--- a/readme.md
+++ b/readme.md
@@ -4,11 +4,17 @@ Simple python script that sends smtp email in bursts using independent processes
 ## Quick Start
 
 1. Edit `burstVars.py` as needed for your tests.
-  2. Start testing by executing `burstMain.py` from the command line.
+2. Start testing by executing `burstMain.py` from the command line.
 
      ```
      $ python ./burstMain.py
      ```
+
+To open and hold idle TCP connections instead of sending mail:
+
+```bash
+$ python ./burstMain.py --idle-sockets --duration 60
+```
 
 ## Running Tests
 

--- a/tests/test_idle_mode.py
+++ b/tests/test_idle_mode.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import burstMain
+
+class DummySocket:
+    def __init__(self):
+        self.closed = False
+    def close(self):
+        self.closed = True
+
+
+def test_idle_socket_mode_opens_and_closes(monkeypatch):
+    opened = []
+
+    def fake_create_connection(addr):
+        s = DummySocket()
+        opened.append(s)
+        return s
+
+    monkeypatch.setattr(burstMain.socket, 'create_connection', fake_create_connection)
+    monkeypatch.setattr(burstMain.signal, 'signal', lambda *args, **kwargs: None)
+    monkeypatch.setattr(burstMain.time, 'sleep', lambda x: None)
+
+    burstMain.idle_socket_mode(0.01)
+
+    assert opened
+    assert all(s.closed for s in opened)


### PR DESCRIPTION
## Summary
- add a CLI flag for opening idle sockets
- maintain sockets for a configurable duration and close on shutdown
- document new CLI feature
- add tests for idle socket mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685adc838bd883258d164c858fe3f59c