### PR TITLE
Add helper scripts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,11 +16,24 @@ Simple python script that sends smtp email in bursts using independent processes
 
 ## Running Tests
 
-Execute the unit tests with `pytest` from the repository root:
+Execute the unit tests using the helper script:
 
 ```bash
-$ pytest
+$ ./scripts/run_tests.sh
 ```
+
+The script simply invokes `pytest --cov` and collects coverage information.
+
+## Packaging
+
+Build standalone executables with [PyInstaller](https://www.pyinstaller.org/).
+Run the packaging script on the target platform (Linux, macOS or Windows):
+
+```bash
+$ ./scripts/package.sh
+```
+
+The resulting binaries will be placed in `dist/<platform>`.
 
 ## License
 

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+PLATFORM="$(uname | tr '[:upper:]' '[:lower:]')"
+
+case "$PLATFORM" in
+    linux*)
+        OUTDIR="dist/linux"
+        ;;
+    darwin*)
+        OUTDIR="dist/macos"
+        ;;
+    msys*|mingw*|cygwin*)
+        OUTDIR="dist/windows"
+        ;;
+    *)
+        echo "Unsupported platform: $PLATFORM"
+        exit 1
+        ;;
+esac
+
+pyinstaller --onefile burstMain.py --distpath "$OUTDIR"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+pytest --cov


### PR DESCRIPTION
## Summary
- add `scripts` directory with helper scripts for running tests and building packages
- reference the new scripts in the README

## Testing
- `./scripts/run_tests.sh`
- `./scripts/package.sh` *(fails without `pyinstaller`; `pip install pyinstaller` then rerun)*

------
https://chatgpt.com/codex/tasks/task_e_685add0ccf6c8325a07db8401e765229