### PR TITLE
Add config file support

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,0 +1,12 @@
+server: smtp.example.com
+sender: from@example.com
+receivers:
+  - to1@example.com
+  - to2@example.com
+emails_per_burst: 10
+bursts: 5
+email_delay: 0.5
+burst_delay: 1
+size: 1024
+stop_on_fail: true
+stop_fail_count: 5

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,9 @@ Simple python script that sends smtp email in bursts using independent processes
 
    Use `-h`/`--help` to see all available options.
 
+An optional `--config` flag can load settings from a JSON or YAML file.
+See `examples/config.yaml` for a reference.
+
 ## Running Tests
 
 Execute the unit tests with `pytest` from the repository root:

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,0 +1,36 @@
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import burst_cli
+
+
+def test_json_config_parsing(tmp_path):
+    cfg = {"server": "json.example.com", "bursts": 2}
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps(cfg))
+
+    args = burst_cli.parse_args(["--config", str(cfg_path)])
+    assert args.server == "json.example.com"
+    assert args.bursts == 2
+
+
+def test_cli_overrides_config(tmp_path):
+    cfg = {"server": "should.be.overridden"}
+    cfg_path = tmp_path / "c.json"
+    cfg_path.write_text(json.dumps(cfg))
+
+    args = burst_cli.parse_args(["--config", str(cfg_path), "--server", "cli.example.com"])
+    assert args.server == "cli.example.com"
+
+
+def test_yaml_config_parsing(tmp_path):
+    yaml_cfg = "server: yaml.example.com\n"
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml_cfg)
+
+    args = burst_cli.parse_args(["--config", str(cfg_path)])
+    assert args.server == "yaml.example.com"


### PR DESCRIPTION
## Summary
- allow specifying a JSON/YAML config file with `--config`
- parse the config file and merge with CLI arguments
- document usage of the config file
- provide example config
- test config handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685add63403c8325ac32701fb80cf932