### PR TITLE
Fix parse_server host handling

### DIFF
--- a/smtpburst/send.py
+++ b/smtpburst/send.py
@@ -110,7 +110,6 @@ def parse_server(server: str) -> Tuple[str, int]:
         try:
             port = int(port_str)
         except ValueError:
-            host = server
             port = 25
     else:
         host = server

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -48,6 +48,12 @@ def test_parse_server_with_port():
     assert port == 2525
 
 
+def test_parse_server_bad_port():
+    host, port = burstGen.parse_server("example.com:bad")
+    assert host == "example.com"
+    assert port == 25
+
+
 def test_open_sockets_creates_connections(monkeypatch):
     connections = []
 


### PR DESCRIPTION
## Summary
- keep the parsed hostname when a port can't be parsed
- verify server strings with bad ports default to port 25

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b0325ad208325a8b8d65e29e1c4f8