### PR TITLE
Refactor configuration into dataclass

### DIFF
--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -2,7 +2,7 @@ import argparse
 import json
 from typing import Any, Dict
 
-from . import config as cfg
+from .config import Config
 
 try:
     import yaml
@@ -24,41 +24,43 @@ def load_config(path: str) -> Dict[str, Any]:
     return data
 
 
-def build_parser() -> argparse.ArgumentParser:
+def build_parser(cfg: Config | None = None) -> argparse.ArgumentParser:
     """Return argument parser for smtp-burst."""
+    if cfg is None:
+        cfg = Config()
     parser = argparse.ArgumentParser(
         description="Send bursts of SMTP emails for testing purposes"
     )
     parser.add_argument("--config", help="Path to JSON/YAML config file")
-    parser.add_argument("--server", default=cfg.SB_SERVER, help="SMTP server to connect to")
-    parser.add_argument("--sender", default=cfg.SB_SENDER, help="Envelope sender address")
-    parser.add_argument("--receivers", nargs="+", default=cfg.SB_RECEIVERS, help="Space separated list of recipient addresses")
-    parser.add_argument("--subject", default=cfg.SB_SUBJECT, help="Email subject line")
+    parser.add_argument("--server", default=cfg.server, help="SMTP server to connect to")
+    parser.add_argument("--sender", default=cfg.sender, help="Envelope sender address")
+    parser.add_argument("--receivers", nargs="+", default=cfg.receivers, help="Space separated list of recipient addresses")
+    parser.add_argument("--subject", default=cfg.subject, help="Email subject line")
     parser.add_argument("--body-file", help="File containing email body text")
-    parser.add_argument("--emails-per-burst", type=int, default=cfg.SB_SGEMAILS, help="Number of emails per burst")
-    parser.add_argument("--bursts", type=int, default=cfg.SB_BURSTS, help="Number of bursts to send")
-    parser.add_argument("--email-delay", type=float, default=cfg.SB_SGEMAILSPSEC, help="Delay in seconds between individual emails")
-    parser.add_argument("--burst-delay", type=float, default=cfg.SB_BURSTSPSEC, help="Delay in seconds between bursts")
+    parser.add_argument("--emails-per-burst", type=int, default=cfg.emails_per_burst, help="Number of emails per burst")
+    parser.add_argument("--bursts", type=int, default=cfg.bursts, help="Number of bursts to send")
+    parser.add_argument("--email-delay", type=float, default=cfg.email_delay, help="Delay in seconds between individual emails")
+    parser.add_argument("--burst-delay", type=float, default=cfg.burst_delay, help="Delay in seconds between bursts")
     parser.add_argument("--open-sockets", type=int, default=0, help="Open N TCP sockets and hold them open instead of sending email")
     parser.add_argument("--port", type=int, default=25, help="TCP port to use for socket mode")
-    parser.add_argument("--size", type=int, default=cfg.SB_SIZE, help="Random data size in bytes appended to each message")
-    parser.add_argument("--stop-on-fail", action="store_true", default=cfg.SB_STOPFAIL, help="Stop execution when --stop-fail-count failures occur")
-    parser.add_argument("--stop-fail-count", type=int, default=cfg.SB_STOPFQNT, help="Number of failed emails that triggers stopping")
+    parser.add_argument("--size", type=int, default=cfg.size, help="Random data size in bytes appended to each message")
+    parser.add_argument("--stop-on-fail", action="store_true", default=cfg.stop_on_fail, help="Stop execution when --stop-fail-count failures occur")
+    parser.add_argument("--stop-fail-count", type=int, default=cfg.stop_fail_count, help="Number of failed emails that triggers stopping")
     parser.add_argument("--proxy-file", help="File containing SOCKS proxies to rotate through")
     parser.add_argument("--userlist", help="Username wordlist for SMTP AUTH")
     parser.add_argument("--passlist", help="Password wordlist for SMTP AUTH")
-    parser.add_argument("--ssl", action="store_true", default=cfg.SB_SSL, help="Use SMTPS (SSL/TLS) connection")
-    parser.add_argument("--starttls", action="store_true", default=cfg.SB_STARTTLS, help="Issue STARTTLS after connecting")
+    parser.add_argument("--ssl", action="store_true", default=cfg.ssl, help="Use SMTPS (SSL/TLS) connection")
+    parser.add_argument("--starttls", action="store_true", default=cfg.starttls, help="Issue STARTTLS after connecting")
     return parser
 
 
-def parse_args(args=None) -> argparse.Namespace:
+def parse_args(args=None, cfg: Config | None = None) -> argparse.Namespace:
     """Parse command line arguments, optionally merging a config file."""
     config_parser = argparse.ArgumentParser(add_help=False)
     config_parser.add_argument("--config")
     config_args, _ = config_parser.parse_known_args(args)
 
-    parser = build_parser()
+    parser = build_parser(cfg)
     if config_args.config:
         try:
             config_data = load_config(config_args.config)

--- a/smtpburst/config.py
+++ b/smtpburst/config.py
@@ -1,38 +1,48 @@
+"""Configuration utilities for smtp-burst."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
 # Size constants
 SZ_KILOBYTE = 1024
 SZ_MEGABYTE = 1024 * SZ_KILOBYTE
 SZ_GIGABYTE = 1024 * SZ_MEGABYTE
 SZ_TERABYTE = 1024 * SZ_GIGABYTE
 
-# Default runtime parameters
-SB_SGEMAILS = 5
-SB_SGEMAILSPSEC = 1
-SB_BURSTS = 3
-SB_BURSTSPSEC = 3
-SB_TOTAL = SB_SGEMAILS * SB_BURSTS
-SB_SIZE = 5 * SZ_MEGABYTE * 2
-SB_STOPFAIL = True
-SB_STOPFQNT = 3
-SB_FAILCOUNT = 0
 
-SB_SENDER = 'from@sender.com'
-SB_RECEIVERS = ['to@receiver.com']
-SB_SERVER = 'smtp.mail.com'
-SB_SUBJECT = 'smtp-burst test'
-SB_BODY = 'smtp-burst message body'
-SB_MESSAGEC = """From: SENDER <from@sender.com>
-To: RECEIVER <to@receiver.com>
-Subject: SUBJECT
+@dataclass
+class Config:
+    """Runtime configuration values."""
 
-MESSAGE DATA
+    # Message options
+    server: str = "smtp.mail.com"
+    sender: str = "from@sender.com"
+    receivers: list[str] = field(default_factory=lambda: ["to@receiver.com"])
+    subject: str = "smtp-burst test"
+    body: str = "smtp-burst message body"
 
-"""
+    # Burst behaviour
+    emails_per_burst: int = 5
+    email_delay: float = 1.0
+    bursts: int = 3
+    burst_delay: float = 3.0
 
-# Proxy and authentication defaults
-SB_PROXIES = []
-SB_USERLIST = []
-SB_PASSLIST = []
+    # Message size and failure handling
+    size: int = 5 * SZ_MEGABYTE * 2
+    stop_on_fail: bool = True
+    stop_fail_count: int = 3
 
-# Security options
-SB_SSL = False
-SB_STARTTLS = False
+    # Proxy and authentication settings
+    proxies: list[str] = field(default_factory=list)
+    userlist: list[str] = field(default_factory=list)
+    passlist: list[str] = field(default_factory=list)
+
+    # Security options
+    ssl: bool = False
+    starttls: bool = False
+
+    @property
+    def total(self) -> int:
+        """Total number of emails that will be sent."""
+        return self.emails_per_burst * self.bursts

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -42,7 +42,7 @@ def test_main_spawns_processes(monkeypatch):
     monkeypatch.setattr(main_mod, 'Process', DummyProcess)
 
     monkeypatch.setattr(main_mod, 'time', type('T', (), {'sleep': lambda *a, **k: None}))
-    monkeypatch.setattr(send, 'appendMessage', lambda: b'msg')
+    monkeypatch.setattr(send, 'appendMessage', lambda cfg: b'msg')
     monkeypatch.setattr(send, 'sizeof_fmt', lambda n: str(n))
 
     main_mod.main(['--emails-per-burst', '2', '--bursts', '3'])


### PR DESCRIPTION
## Summary
- encapsulate runtime options in `Config` dataclass
- update CLI helpers to work with a `Config` instance
- refactor main entry point and sending utilities to consume `Config`
- adjust tests for new configuration object

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bb54082c48325aef925f2699a7059