### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest coverage build pyinstaller
+          pip install -e .
+      - name: Run tests
+        run: |
+          pytest
+      - name: Build wheel and sdist
+        run: |
+          python -m build
+      - name: Build standalone binary
+        run: |
+          ./scripts/package.sh
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: smtp-burst-artifacts
+          path: dist/


### PR DESCRIPTION
## Summary
- add GitHub Actions pipeline that installs dependencies, runs tests, and builds both wheels and standalone binaries

## Testing
- `pytest -q`
- `python -m build`
- `./scripts/package.sh`


------
https://chatgpt.com/codex/tasks/task_e_685bb740fe588325b7bb7636131c0cb2