### PR TITLE
Refactor runtime options into dataclass

### DIFF
--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -2,7 +2,7 @@ import argparse
 import json
 from typing import Any, Dict
 
-from . import config as cfg
+from .config import Config
 
 try:
     import yaml
@@ -24,7 +24,7 @@ def load_config(path: str) -> Dict[str, Any]:
     return data
 
 
-def build_parser() -> argparse.ArgumentParser:
+def build_parser(cfg: Config) -> argparse.ArgumentParser:
     """Return argument parser for smtp-burst."""
     parser = argparse.ArgumentParser(
         description="Send bursts of SMTP emails for testing purposes"
@@ -58,13 +58,16 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def parse_args(args=None) -> argparse.Namespace:
+def parse_args(args=None, cfg: Config | None = None) -> argparse.Namespace:
     """Parse command line arguments, optionally merging a config file."""
+    if cfg is None:
+        cfg = Config()
+
     config_parser = argparse.ArgumentParser(add_help=False)
     config_parser.add_argument("--config")
     config_args, _ = config_parser.parse_known_args(args)
 
-    parser = build_parser()
+    parser = build_parser(cfg)
     if config_args.config:
         try:
             config_data = load_config(config_args.config)

--- a/smtpburst/config.py
+++ b/smtpburst/config.py
@@ -1,46 +1,49 @@
+from dataclasses import dataclass, field
+from typing import List, Optional, TextIO
+
 # Size constants
 SZ_KILOBYTE = 1024
 SZ_MEGABYTE = 1024 * SZ_KILOBYTE
 SZ_GIGABYTE = 1024 * SZ_MEGABYTE
 SZ_TERABYTE = 1024 * SZ_GIGABYTE
 
-# Default runtime parameters
-SB_SGEMAILS = 5
-SB_SGEMAILSPSEC = 1
-SB_BURSTS = 3
-SB_BURSTSPSEC = 3
-SB_TOTAL = SB_SGEMAILS * SB_BURSTS
-SB_SIZE = 5 * SZ_MEGABYTE * 2
-SB_STOPFAIL = True
-SB_STOPFQNT = 3
-SB_FAILCOUNT = 0
 
-SB_SENDER = 'from@sender.com'
-SB_RECEIVERS = ['to@receiver.com']
-SB_SERVER = 'smtp.mail.com'
-SB_SUBJECT = 'smtp-burst test'
-SB_BODY = 'smtp-burst message body'
-SB_MESSAGEC = """From: SENDER <from@sender.com>
-To: RECEIVER <to@receiver.com>
-Subject: SUBJECT
+@dataclass
+class Config:
+    """Runtime configuration options."""
 
-MESSAGE DATA
+    SB_SGEMAILS: int = 5
+    SB_SGEMAILSPSEC: float = 1
+    SB_BURSTS: int = 3
+    SB_BURSTSPSEC: float = 3
+    SB_SIZE: int = 5 * SZ_MEGABYTE * 2
+    SB_STOPFAIL: bool = True
+    SB_STOPFQNT: int = 3
 
-"""
+    SB_SENDER: str = "from@sender.com"
+    SB_RECEIVERS: List[str] = field(default_factory=lambda: ["to@receiver.com"])
+    SB_SERVER: str = "smtp.mail.com"
+    SB_SUBJECT: str = "smtp-burst test"
+    SB_BODY: str = "smtp-burst message body"
 
-# Proxy and authentication defaults
-SB_PROXIES = []
-SB_USERLIST = []
-SB_PASSLIST = []
+    # Proxy and authentication defaults
+    SB_PROXIES: List[str] = field(default_factory=list)
+    SB_USERLIST: List[str] = field(default_factory=list)
+    SB_PASSLIST: List[str] = field(default_factory=list)
 
-# Security options
-SB_SSL = False
-SB_STARTTLS = False
+    # Security options
+    SB_SSL: bool = False
+    SB_STARTTLS: bool = False
 
-# Data generation options
-SB_DATA_MODE = 'ascii'
-SB_DICT_WORDS = []
-SB_REPEAT_STRING = ''
-SB_PER_BURST_DATA = False
-SB_SECURE_RANDOM = False
-SB_RAND_STREAM = None
+    # Data generation options
+    SB_DATA_MODE: str = "ascii"
+    SB_DICT_WORDS: List[str] = field(default_factory=list)
+    SB_REPEAT_STRING: str = ""
+    SB_PER_BURST_DATA: bool = False
+    SB_SECURE_RANDOM: bool = False
+    SB_RAND_STREAM: Optional[TextIO] = None
+
+    @property
+    def SB_TOTAL(self) -> int:
+        """Total number of emails to send."""
+        return self.SB_SGEMAILS * self.SB_BURSTS

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -5,6 +5,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from smtpburst import cli as burst_cli
+from smtpburst.config import Config
 
 
 def test_json_config_parsing(tmp_path):
@@ -12,7 +13,7 @@ def test_json_config_parsing(tmp_path):
     cfg_path = tmp_path / "config.json"
     cfg_path.write_text(json.dumps(cfg))
 
-    args = burst_cli.parse_args(["--config", str(cfg_path)])
+    args = burst_cli.parse_args(["--config", str(cfg_path)], Config())
     assert args.server == "json.example.com"
     assert args.bursts == 2
 
@@ -22,7 +23,7 @@ def test_cli_overrides_config(tmp_path):
     cfg_path = tmp_path / "c.json"
     cfg_path.write_text(json.dumps(cfg))
 
-    args = burst_cli.parse_args(["--config", str(cfg_path), "--server", "cli.example.com"])
+    args = burst_cli.parse_args(["--config", str(cfg_path), "--server", "cli.example.com"], Config())
     assert args.server == "cli.example.com"
 
 
@@ -31,49 +32,49 @@ def test_yaml_config_parsing(tmp_path):
     cfg_path = tmp_path / "config.yaml"
     cfg_path.write_text(yaml_cfg)
 
-    args = burst_cli.parse_args(["--config", str(cfg_path)])
+    args = burst_cli.parse_args(["--config", str(cfg_path)], Config())
     assert args.server == "yaml.example.com"
 
 
 def test_open_sockets_option():
-    args = burst_cli.parse_args(["--open-sockets", "5"])
+    args = burst_cli.parse_args(["--open-sockets", "5"], Config())
     assert args.open_sockets == 5
 
 
 def test_proxy_file_option(tmp_path):
     proxy_file = tmp_path / "proxies.txt"
     proxy_file.write_text("127.0.0.1:1080\n")
-    args = burst_cli.parse_args(["--proxy-file", str(proxy_file)])
+    args = burst_cli.parse_args(["--proxy-file", str(proxy_file)], Config())
     assert args.proxy_file == str(proxy_file)
 
 
 def test_ssl_flag():
-    args = burst_cli.parse_args(["--ssl"])
+    args = burst_cli.parse_args(["--ssl"], Config())
     assert args.ssl
 
 
 def test_starttls_flag():
-    args = burst_cli.parse_args(["--starttls"])
+    args = burst_cli.parse_args(["--starttls"], Config())
     assert args.starttls
 
 
 def test_subject_option():
-    args = burst_cli.parse_args(["--subject", "MySub"])
+    args = burst_cli.parse_args(["--subject", "MySub"], Config())
     assert args.subject == "MySub"
 
 
 def test_body_file_option(tmp_path):
     body_file = tmp_path / "body.txt"
     body_file.write_text("hello")
-    args = burst_cli.parse_args(["--body-file", str(body_file)])
+    args = burst_cli.parse_args(["--body-file", str(body_file)], Config())
     assert args.body_file == str(body_file)
 
 
 def test_data_mode_option():
-    args = burst_cli.parse_args(["--data-mode", "binary"])
+    args = burst_cli.parse_args(["--data-mode", "binary"], Config())
     assert args.data_mode == "binary"
 
 
 def test_per_burst_flag():
-    args = burst_cli.parse_args(["--per-burst-data"])
+    args = burst_cli.parse_args(["--per-burst-data"], Config())
     assert args.per_burst_data

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -32,9 +32,10 @@ def test_main_spawns_processes(monkeypatch):
     started = []
     joined = []
     class DummyProcess:
-        def __init__(self, target=None, args=()):
+        def __init__(self, target=None, args=(), kwargs=None):
             self.target = target
             self.args = args
+            self.kwargs = kwargs or {}
         def start(self):
             started.append(self.args)
         def join(self):
@@ -42,7 +43,7 @@ def test_main_spawns_processes(monkeypatch):
     monkeypatch.setattr(main_mod, 'Process', DummyProcess)
 
     monkeypatch.setattr(main_mod, 'time', type('T', (), {'sleep': lambda *a, **k: None}))
-    monkeypatch.setattr(send, 'appendMessage', lambda: b'msg')
+    monkeypatch.setattr(send, 'appendMessage', lambda cfg: b'msg')
     monkeypatch.setattr(send, 'sizeof_fmt', lambda n: str(n))
 
     main_mod.main(['--emails-per-burst', '2', '--bursts', '3'])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 from smtpburst.send import sizeof_fmt, sendmail
 from smtpburst import send as burstGen
 from smtpburst import datagen
-from smtpburst import config as burstVars
+from smtpburst.config import Config
 from unittest.mock import MagicMock
 
 
@@ -27,12 +27,13 @@ def test_sendmail_exits_when_failcount_exceeded(monkeypatch):
         def __init__(self, value):
             self.value = value
 
-    fail_counter = DummyCounter(burstVars.SB_STOPFQNT)
+    cfg = Config()
+    fail_counter = DummyCounter(cfg.SB_STOPFQNT)
 
     smtp_mock = MagicMock()
     monkeypatch.setattr(burstGen.smtplib, "SMTP", smtp_mock)
 
-    sendmail(1, 1, fail_counter, b"msg")
+    sendmail(1, 1, fail_counter, b"msg", cfg)
 
     assert not smtp_mock.called
 
@@ -102,8 +103,9 @@ def test_sendmail_reports_auth_success(monkeypatch, capsys):
         def __init__(self, value=0):
             self.value = value
 
+    cfg = Config()
     counter = DummyCounter()
-    sendmail(1, 1, counter, b"msg", server="s", users=["u"], passwords=["p"])
+    sendmail(1, 1, counter, b"msg", cfg, server="s", users=["u"], passwords=["p"])
     captured = capsys.readouterr().out
     assert "Auth success: u:p" in captured
 
@@ -135,8 +137,9 @@ def test_sendmail_uses_ssl(monkeypatch):
         def __init__(self, value=0):
             self.value = value
 
+    cfg = Config()
     counter = DummyCounter()
-    sendmail(1, 1, counter, b"msg", use_ssl=True)
+    sendmail(1, 1, counter, b"msg", cfg, use_ssl=True)
     assert calls.get('ssl') and not calls.get('smtp')
 
 
@@ -165,18 +168,20 @@ def test_sendmail_calls_starttls(monkeypatch):
         def __init__(self, value=0):
             self.value = value
 
+    cfg = Config()
     counter = DummyCounter()
-    sendmail(1, 1, counter, b"msg", start_tls=True)
+    sendmail(1, 1, counter, b"msg", cfg, start_tls=True)
     assert called.get('starttls')
 
 
 def test_append_message_uses_subject_and_body(monkeypatch):
-    burstVars.SB_SENDER = 'a@b.com'
-    burstVars.SB_RECEIVERS = ['c@d.com']
-    burstVars.SB_SUBJECT = 'Sub'
-    burstVars.SB_BODY = 'Body'
-    burstVars.SB_SIZE = 0
-    msg = burstGen.appendMessage()
+    cfg = Config()
+    cfg.SB_SENDER = 'a@b.com'
+    cfg.SB_RECEIVERS = ['c@d.com']
+    cfg.SB_SUBJECT = 'Sub'
+    cfg.SB_BODY = 'Body'
+    cfg.SB_SIZE = 0
+    msg = burstGen.appendMessage(cfg)
     assert b'Subject: Sub' in msg
     assert b'Body' in msg
 


### PR DESCRIPTION
## Summary
- keep size constants but consolidate runtime options into `Config` dataclass
- adjust CLI and entry point to work with a `Config` instance
- update message sending helpers to accept the new config object
- modify tests to create and pass config instances

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bc50930b08325b0579f4d742ff9cd