### PR TITLE
Add DNS discovery features

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,10 @@ description = "Send bursts of SMTP emails for testing"
 authors = [{name="supermarsx"}]
 readme = "readme.md"
 requires-python = ">=3.11"
-dependencies = ["PyYAML"]
+dependencies = [
+    "PyYAML",
+    "dnspython",
+]
 
 [project.scripts]
 smtp-burst = "smtpburst.__main__:main"

--- a/smtpburst/__init__.py
+++ b/smtpburst/__init__.py
@@ -1,5 +1,13 @@
 """smtp-burst library package."""
 
-from . import send, config, cli, datagen, attacks, report
+from . import send, config, cli, datagen, attacks, report, discovery
 
-__all__ = ["send", "config", "cli", "datagen", "attacks", "report"]
+__all__ = [
+    "send",
+    "config",
+    "cli",
+    "datagen",
+    "attacks",
+    "report",
+    "discovery",
+]

--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -5,6 +5,8 @@ from multiprocessing import Manager, Process
 from smtpburst.config import Config
 from smtpburst import send
 from smtpburst import cli
+from smtpburst import discovery
+from smtpburst import report
 
 
 def main(argv=None):
@@ -110,6 +112,26 @@ def main(argv=None):
             cfg.SB_RAND_STREAM.close()
         except Exception:
             pass
+
+    results = {}
+    if args.check_dmarc:
+        results['dmarc'] = discovery.check_dmarc(args.check_dmarc)
+    if args.check_spf:
+        results['spf'] = discovery.check_spf(args.check_spf)
+    if args.check_dkim:
+        results['dkim'] = discovery.check_dkim(args.check_dkim)
+    if args.check_srv:
+        results['srv'] = discovery.check_srv(args.check_srv)
+    if args.check_soa:
+        results['soa'] = discovery.check_soa(args.check_soa)
+    if args.check_txt:
+        results['txt'] = discovery.check_txt(args.check_txt)
+    if args.ping:
+        results['ping'] = discovery.ping(args.ping)
+    if args.traceroute:
+        results['traceroute'] = discovery.traceroute(args.traceroute)
+    if results:
+        print(report.ascii_report(results))
 
 
 if __name__ == "__main__":

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -55,6 +55,14 @@ def build_parser(cfg: Config) -> argparse.ArgumentParser:
     parser.add_argument("--passlist", help="Password wordlist for SMTP AUTH")
     parser.add_argument("--ssl", action="store_true", default=cfg.SB_SSL, help="Use SMTPS (SSL/TLS) connection")
     parser.add_argument("--starttls", action="store_true", default=cfg.SB_STARTTLS, help="Issue STARTTLS after connecting")
+    parser.add_argument("--check-dmarc", help="Domain to query DMARC record for")
+    parser.add_argument("--check-spf", help="Domain to query SPF record for")
+    parser.add_argument("--check-dkim", help="Domain to query DKIM record for")
+    parser.add_argument("--check-srv", help="Service to query SRV record for")
+    parser.add_argument("--check-soa", help="Domain to query SOA record for")
+    parser.add_argument("--check-txt", help="Domain to query TXT record for")
+    parser.add_argument("--ping", help="Host to ping")
+    parser.add_argument("--traceroute", help="Host to traceroute")
     return parser
 
 

--- a/smtpburst/discovery.py
+++ b/smtpburst/discovery.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+"""DNS and network discovery utilities."""
+
+from dns import resolver
+import subprocess
+from typing import List, Any
+
+
+def _lookup(domain: str, record: str) -> List[str]:
+    """Return record strings for ``domain`` and ``record`` type."""
+    try:
+        answers = resolver.resolve(domain, record)
+        return [ans.to_text() for ans in answers]
+    except Exception as exc:  # pragma: no cover - resolver may raise many errors
+        return [f"error: {exc}"]
+
+
+def check_dmarc(domain: str) -> List[str]:
+    """Return DMARC TXT records for ``domain``."""
+    return _lookup(f"_dmarc.{domain}", "TXT")
+
+
+def check_spf(domain: str) -> List[str]:
+    """Return SPF TXT records for ``domain``."""
+    records = _lookup(domain, "TXT")
+    return [r for r in records if r.lower().startswith("v=spf1")]
+
+
+def check_dkim(domain: str, selector: str = "default") -> List[str]:
+    """Return DKIM TXT records for ``domain`` using ``selector``."""
+    return _lookup(f"{selector}._domainkey.{domain}", "TXT")
+
+
+def check_srv(name: str) -> List[str]:
+    """Return SRV records for ``name``."""
+    return _lookup(name, "SRV")
+
+
+def check_soa(domain: str) -> List[str]:
+    """Return SOA record for ``domain``."""
+    return _lookup(domain, "SOA")
+
+
+def check_txt(domain: str) -> List[str]:
+    """Return TXT records for ``domain``."""
+    return _lookup(domain, "TXT")
+
+
+def ping(host: str) -> str:
+    """Return result of ``ping`` command for ``host``."""
+    try:
+        proc = subprocess.run([
+            "ping",
+            "-c",
+            "1",
+            host,
+        ], capture_output=True, text=True, check=False)
+        return proc.stdout.strip()
+    except Exception as exc:  # pragma: no cover - system might not have ping
+        return str(exc)
+
+
+def traceroute(host: str) -> str:
+    """Return result of ``traceroute`` command for ``host``."""
+    try:
+        proc = subprocess.run([
+            "traceroute",
+            host,
+        ], capture_output=True, text=True, check=False)
+        return proc.stdout.strip()
+    except Exception as exc:  # pragma: no cover
+        return str(exc)
+

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -78,3 +78,11 @@ def test_data_mode_option():
 def test_per_burst_flag():
     args = burst_cli.parse_args(["--per-burst-data"], Config())
     assert args.per_burst_data
+
+def test_discovery_options():
+    args = burst_cli.parse_args([
+        '--check-dmarc', 'ex.com',
+        '--ping', 'host'
+    ], Config())
+    assert args.check_dmarc == 'ex.com'
+    assert args.ping == 'host'

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,51 @@
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from smtpburst import discovery
+
+
+class DummyAns:
+    def __init__(self, text):
+        self._text = text
+
+    def to_text(self):
+        return self._text
+
+
+def test_check_dmarc(monkeypatch):
+    def fake_resolve(domain, record):
+        assert domain == '_dmarc.example.com'
+        assert record == 'TXT'
+        return [DummyAns('v=DMARC1; p=none')]
+
+    monkeypatch.setattr(discovery.resolver, 'resolve', fake_resolve)
+    assert discovery.check_dmarc('example.com') == ['v=DMARC1; p=none']
+
+
+def test_check_spf(monkeypatch):
+    def fake_resolve(domain, record):
+        return [DummyAns('v=spf1 include:foo'), DummyAns('hello')]
+
+    monkeypatch.setattr(discovery.resolver, 'resolve', fake_resolve)
+    assert discovery.check_spf('ex.com') == ['v=spf1 include:foo']
+
+
+def test_ping(monkeypatch):
+    def fake_run(cmd, capture_output, text, check):
+        assert cmd[-1] == 'host'
+        return SimpleNamespace(stdout='pong')
+
+    monkeypatch.setattr(discovery.subprocess, 'run', fake_run)
+    assert discovery.ping('host') == 'pong'
+
+
+def test_traceroute(monkeypatch):
+    def fake_run(cmd, capture_output, text, check):
+        assert cmd[-1] == 'host'
+        return SimpleNamespace(stdout='trace')
+
+    monkeypatch.setattr(discovery.subprocess, 'run', fake_run)
+    assert discovery.traceroute('host') == 'trace'


### PR DESCRIPTION
## Summary
- add a new discovery module for DNS and network checks
- expose new CLI flags to run discovery tests
- integrate discovery checks into smtp-burst main workflow
- include dnspython as a dependency
- test discovery utilities and new CLI options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bd22f63b083258fd3356110555973