### PR TITLE
Add RBL and open relay checks

### DIFF
--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -126,6 +126,11 @@ def main(argv=None):
         results['soa'] = discovery.check_soa(args.check_soa)
     if args.check_txt:
         results['txt'] = discovery.check_txt(args.check_txt)
+    if args.check_rbl:
+        results['rbl'] = discovery.check_rbl(args.check_rbl[0], args.check_rbl[1:])
+    if args.test_open_relay:
+        host, port = send.parse_server(args.server)
+        results['open_relay'] = discovery.test_open_relay(host, port)
     if args.ping:
         results['ping'] = discovery.ping(args.ping)
     if args.traceroute:

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -61,6 +61,16 @@ def build_parser(cfg: Config) -> argparse.ArgumentParser:
     parser.add_argument("--check-srv", help="Service to query SRV record for")
     parser.add_argument("--check-soa", help="Domain to query SOA record for")
     parser.add_argument("--check-txt", help="Domain to query TXT record for")
+    parser.add_argument(
+        "--check-rbl",
+        nargs="+",
+        help="IP followed by one or more RBL zones to query",
+    )
+    parser.add_argument(
+        "--test-open-relay",
+        action="store_true",
+        help="Test if the target SMTP server is an open relay",
+    )
     parser.add_argument("--ping", help="Host to ping")
     parser.add_argument("--traceroute", help="Host to traceroute")
     return parser

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -86,3 +86,15 @@ def test_discovery_options():
     ], Config())
     assert args.check_dmarc == 'ex.com'
     assert args.ping == 'host'
+
+
+def test_check_rbl_option():
+    args = burst_cli.parse_args([
+        '--check-rbl', '1.2.3.4', 'rbl.example'
+    ], Config())
+    assert args.check_rbl == ['1.2.3.4', 'rbl.example']
+
+
+def test_test_open_relay_flag():
+    args = burst_cli.parse_args(['--test-open-relay'], Config())
+    assert args.test_open_relay


### PR DESCRIPTION
## Summary
- check DNS blacklists and test servers for open relay behaviour
- expose new `--check-rbl` and `--test-open-relay` CLI options
- display new results in the main program
- test new discovery helpers and CLI flags

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685bd45754f48325bd423aca68b05b95