### PR TITLE
Introduce bombing mode for autonomous bursts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,7 @@ Simple python script that sends smtp email in bursts using independent processes
 - Optional SSL or STARTTLS connections via CLI flags
 - Random payload data appended to each message
 - Customizable subject and message body via CLI options
+- Autonomous bombing mode for hands-off bursts
 - Helper scripts for packaging and running tests
 
 ## Installation

--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -1,6 +1,4 @@
 import sys
-import time
-from multiprocessing import Manager, Process
 
 from smtpburst.config import Config
 from smtpburst import send
@@ -56,62 +54,7 @@ def main(argv=None):
             cfg.SB_BODY = fh.read()
 
     print("Starting smtp-burst")
-    manager = Manager()
-    SB_FAILCOUNT = manager.Value('i', 0)
-
-    print(f"Generating {send.sizeof_fmt(cfg.SB_SIZE)} of data to append to message")
-    SB_MESSAGE = send.appendMessage(cfg)
-    print(f"Message using {send.sizeof_fmt(sys.getsizeof(SB_MESSAGE))} of random data")
-
-    print(
-        "Sending %s messages from %s to %s through %s"
-        % (cfg.SB_TOTAL, cfg.SB_SENDER, cfg.SB_RECEIVERS, cfg.SB_SERVER)
-    )
-
-    for x in range(0, cfg.SB_BURSTS):
-        if cfg.SB_PER_BURST_DATA:
-            SB_MESSAGE = send.appendMessage(cfg)
-        quantity = range(1, cfg.SB_SGEMAILS + 1)
-        procs = []
-
-        if SB_FAILCOUNT.value >= cfg.SB_STOPFQNT and cfg.SB_STOPFAIL:
-            break
-        for number in quantity:
-            if SB_FAILCOUNT.value >= cfg.SB_STOPFQNT and cfg.SB_STOPFAIL:
-                break
-            time.sleep(cfg.SB_SGEMAILSPSEC)
-            proxy = None
-            if cfg.SB_PROXIES:
-                idx = (number + (x * cfg.SB_SGEMAILS) - 1) % len(cfg.SB_PROXIES)
-                proxy = cfg.SB_PROXIES[idx]
-            process = Process(
-                target=send.sendmail,
-                args=(
-                    number + (x * cfg.SB_SGEMAILS),
-                    x + 1,
-                    SB_FAILCOUNT,
-                    SB_MESSAGE,
-                    cfg,
-                ),
-                kwargs={
-                    "server": cfg.SB_SERVER,
-                    "proxy": proxy,
-                    "users": cfg.SB_USERLIST,
-                    "passwords": cfg.SB_PASSLIST,
-                },
-            )
-            procs.append(process)
-            process.start()
-
-        for process in procs:
-            process.join()
-        time.sleep(cfg.SB_BURSTSPSEC)
-
-    if cfg.SB_RAND_STREAM:
-        try:
-            cfg.SB_RAND_STREAM.close()
-        except Exception:
-            pass
+    send.bombing_mode(cfg)
 
     results = {}
     if args.check_dmarc:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,7 +27,7 @@ def test_main_spawns_processes(monkeypatch):
             return DummyValue(typecode, value)
     def manager_factory():
         return DummyManager()
-    monkeypatch.setattr(main_mod, 'Manager', manager_factory)
+    monkeypatch.setattr('multiprocessing.Manager', manager_factory)
 
     started = []
     joined = []
@@ -40,9 +40,9 @@ def test_main_spawns_processes(monkeypatch):
             started.append(self.args)
         def join(self):
             joined.append(self.args)
-    monkeypatch.setattr(main_mod, 'Process', DummyProcess)
+    monkeypatch.setattr('multiprocessing.Process', DummyProcess)
 
-    monkeypatch.setattr(main_mod, 'time', type('T', (), {'sleep': lambda *a, **k: None}))
+    monkeypatch.setattr(send, 'time', type('T', (), {'sleep': lambda *a, **k: None}))
     monkeypatch.setattr(send, 'appendMessage', lambda cfg: b'msg')
     monkeypatch.setattr(send, 'sizeof_fmt', lambda n: str(n))
 


### PR DESCRIPTION
## Summary
- implement `bombing_mode` in `send.py` to autonomously handle burst sending
- call new mode from `__main__` for CLI usage
- update tests for new control flow
- document bombing mode in README

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685bd8223d008325807ff82222d62b0e