### PR TITLE
Add logging controls

### DIFF
--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -1,4 +1,5 @@
 import sys
+import logging
 
 from smtpburst.config import Config
 from smtpburst import send
@@ -6,10 +7,23 @@ from smtpburst import cli
 from smtpburst import discovery
 from smtpburst import report
 
+logger = logging.getLogger(__name__)
+
 
 def main(argv=None):
     cfg = Config()
     args = cli.parse_args(argv, cfg)
+
+    if args.silent:
+        level = logging.CRITICAL
+    elif args.errors_only:
+        level = logging.ERROR
+    elif args.warnings:
+        level = logging.WARNING
+    else:
+        level = logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s:%(message)s")
+    logging.getLogger().setLevel(level)
 
     if args.open_sockets:
         host, srv_port = send.parse_server(args.server)
@@ -53,7 +67,7 @@ def main(argv=None):
         with open(args.body_file, "r", encoding="utf-8") as fh:
             cfg.SB_BODY = fh.read()
 
-    print("Starting smtp-burst")
+    logger.info("Starting smtp-burst")
     send.bombing_mode(cfg)
 
     results = {}
@@ -79,7 +93,7 @@ def main(argv=None):
     if args.traceroute:
         results['traceroute'] = discovery.traceroute(args.traceroute)
     if results:
-        print(report.ascii_report(results))
+        logger.info(report.ascii_report(results))
 
 
 if __name__ == "__main__":

--- a/smtpburst/attacks.py
+++ b/smtpburst/attacks.py
@@ -1,7 +1,11 @@
 import socket
 import struct
 import time
+import logging
 from typing import List
+
+
+logger = logging.getLogger(__name__)
 
 
 def open_sockets(host: str, count: int, port: int = 25):
@@ -10,7 +14,9 @@ def open_sockets(host: str, count: int, port: int = 25):
     for _ in range(count):
         s = socket.create_connection((host, port))
         sockets.append(s)
-    print(f"Opened {len(sockets)} sockets to {host}:{port}. Press Ctrl+C to exit.")
+    logger.info(
+        "Opened %s sockets to %s:%s. Press Ctrl+C to exit.", len(sockets), host, port
+    )
     try:
         while True:
             time.sleep(1)
@@ -34,7 +40,9 @@ def socket_open_time(host: str, count: int, port: int = 25) -> List[float]:
         s.close()
         times.append(end - start)
     avg = sum(times) / len(times) if times else 0
-    print(f"Average open time to {host}:{port} over {count} sockets: {avg:.4f}s")
+    logger.info(
+        "Average open time to %s:%s over %s sockets: %.4fs", host, port, count, avg
+    )
     return times
 
 
@@ -51,7 +59,7 @@ def tcp_syn_flood(host: str, port: int, count: int):
             s.close()
         except Exception:
             pass
-    print(f"Sent {count} SYN packets to {host}:{port}")
+    logger.info("Sent %s SYN packets to %s:%s", count, host, port)
 
 
 def tcp_reset_attack(host: str, port: int):
@@ -64,21 +72,21 @@ def tcp_reset_attack(host: str, port: int):
         s.close()
     except Exception:
         pass
-    print(f"Performed TCP reset attack on {host}:{port}")
+    logger.info("Performed TCP reset attack on %s:%s", host, port)
 
 
 def tcp_reset_flood(host: str, port: int, count: int):
     """Repeated TCP reset attacks."""
     for _ in range(count):
         tcp_reset_attack(host, port)
-    print(f"Performed {count} TCP resets on {host}:{port}")
+    logger.info("Performed %s TCP resets on %s:%s", count, host, port)
 
 
 def smurf_test(target: str, count: int):
     """Simulate a smurf attack by issuing ping requests."""
     for _ in range(count):
         time.sleep(0.01)
-    print(f"Simulated smurf attack against {target} {count} times")
+    logger.info("Simulated smurf attack against %s %s times", target, count)
 
 
 def auto_test(host: str, port: int):

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -73,6 +73,10 @@ def build_parser(cfg: Config) -> argparse.ArgumentParser:
     )
     parser.add_argument("--ping", help="Host to ping")
     parser.add_argument("--traceroute", help="Host to traceroute")
+    level_group = parser.add_mutually_exclusive_group()
+    level_group.add_argument("--silent", action="store_true", help="Suppress all log output")
+    level_group.add_argument("--errors-only", action="store_true", help="Show only error messages")
+    level_group.add_argument("--warnings", action="store_true", help="Show warnings and errors only")
     return parser
 
 

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -98,3 +98,12 @@ def test_check_rbl_option():
 def test_test_open_relay_flag():
     args = burst_cli.parse_args(['--test-open-relay'], Config())
     assert args.test_open_relay
+
+
+def test_logging_cli_flags():
+    args = burst_cli.parse_args(['--silent'], Config())
+    assert args.silent
+    args = burst_cli.parse_args(['--errors-only'], Config())
+    assert args.errors_only
+    args = burst_cli.parse_args(['--warnings'], Config())
+    assert args.warnings

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import pytest
+import logging
 
 # Ensure the project root is on sys.path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -78,7 +79,7 @@ def test_open_sockets_creates_connections(monkeypatch):
     assert connections == [("host", 123)] * 3
 
 
-def test_sendmail_reports_auth_success(monkeypatch, capsys):
+def test_sendmail_reports_auth_success(monkeypatch, caplog):
     class DummySMTP:
         def __init__(self, *args, **kwargs):
             pass
@@ -105,9 +106,9 @@ def test_sendmail_reports_auth_success(monkeypatch, capsys):
 
     cfg = Config()
     counter = DummyCounter()
-    sendmail(1, 1, counter, b"msg", cfg, server="s", users=["u"], passwords=["p"])
-    captured = capsys.readouterr().out
-    assert "Auth success: u:p" in captured
+    with caplog.at_level(logging.INFO, logger="smtpburst.send"):
+        sendmail(1, 1, counter, b"msg", cfg, server="s", users=["u"], passwords=["p"])
+    assert any("Auth success: u:p" in r.getMessage() for r in caplog.records)
 
 
 def test_sendmail_uses_ssl(monkeypatch):


### PR DESCRIPTION
## Summary
- switch print statements to `logging` module
- add CLI flags `--silent`, `--errors-only`, and `--warnings`
- configure logging levels in `__main__`
- update unit tests for new logging behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bdd576ccc8325bbb05be042513efe