### PR TITLE
Add network testing utilities

### DIFF
--- a/smtpburst/__init__.py
+++ b/smtpburst/__init__.py
@@ -1,6 +1,6 @@
 """smtp-burst library package."""
 
-from . import send, config, cli, datagen, attacks, report, discovery
+from . import send, config, cli, datagen, attacks, report, discovery, nettests
 
 __all__ = [
     "send",
@@ -10,4 +10,5 @@ __all__ = [
     "attacks",
     "report",
     "discovery",
+    "nettests",
 ]

--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -4,7 +4,7 @@ import logging
 from smtpburst.config import Config
 from smtpburst import send
 from smtpburst import cli
-from smtpburst import discovery
+from smtpburst import discovery, nettests
 from smtpburst import report
 
 logger = logging.getLogger(__name__)
@@ -83,15 +83,17 @@ def main(argv=None):
         results['soa'] = discovery.check_soa(args.check_soa)
     if args.check_txt:
         results['txt'] = discovery.check_txt(args.check_txt)
-    if args.check_rbl:
-        results['rbl'] = discovery.check_rbl(args.check_rbl[0], args.check_rbl[1:])
-    if args.test_open_relay:
+    if args.blacklist_check:
+        results['blacklist'] = nettests.blacklist_check(
+            args.blacklist_check[0], args.blacklist_check[1:]
+        )
+    if args.open_relay_test:
         host, port = send.parse_server(args.server)
-        results['open_relay'] = discovery.test_open_relay(host, port)
-    if args.ping:
-        results['ping'] = discovery.ping(args.ping)
-    if args.traceroute:
-        results['traceroute'] = discovery.traceroute(args.traceroute)
+        results['open_relay'] = nettests.open_relay_test(host, port)
+    if args.ping_test:
+        results['ping'] = nettests.ping(args.ping_test)
+    if args.traceroute_test:
+        results['traceroute'] = nettests.traceroute(args.traceroute_test)
     if results:
         logger.info(report.ascii_report(results))
 

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -62,17 +62,17 @@ def build_parser(cfg: Config) -> argparse.ArgumentParser:
     parser.add_argument("--check-soa", help="Domain to query SOA record for")
     parser.add_argument("--check-txt", help="Domain to query TXT record for")
     parser.add_argument(
-        "--check-rbl",
+        "--blacklist-check",
         nargs="+",
-        help="IP followed by one or more RBL zones to query",
+        help="IP followed by one or more DNSBL zones to query",
     )
     parser.add_argument(
-        "--test-open-relay",
+        "--open-relay-test",
         action="store_true",
         help="Test if the target SMTP server is an open relay",
     )
-    parser.add_argument("--ping", help="Host to ping")
-    parser.add_argument("--traceroute", help="Host to traceroute")
+    parser.add_argument("--ping-test", help="Host to ping")
+    parser.add_argument("--traceroute-test", help="Host to traceroute")
     level_group = parser.add_mutually_exclusive_group()
     level_group.add_argument("--silent", action="store_true", help="Suppress all log output")
     level_group.add_argument("--errors-only", action="store_true", help="Show only error messages")

--- a/smtpburst/nettests.py
+++ b/smtpburst/nettests.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+"""Network test utilities such as ping, traceroute and open relay checks."""
+
+from dns import resolver
+import ipaddress
+import smtplib
+import subprocess
+from typing import List, Dict
+
+
+def ping(host: str) -> str:
+    """Return output of ``ping`` command for ``host``."""
+    try:
+        proc = subprocess.run(
+            ["ping", "-c", "1", host],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return proc.stdout.strip()
+    except Exception as exc:  # pragma: no cover - ping may not exist
+        return str(exc)
+
+
+def traceroute(host: str) -> str:
+    """Return output of ``traceroute`` command for ``host``."""
+    try:
+        proc = subprocess.run(
+            ["traceroute", host],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return proc.stdout.strip()
+    except Exception as exc:  # pragma: no cover - traceroute may not exist
+        return str(exc)
+
+
+def open_relay_test(host: str, port: int = 25) -> bool:
+    """Return ``True`` if ``host`` appears to be an open relay."""
+    try:
+        with smtplib.SMTP(host, port, timeout=10) as smtp:
+            smtp.helo("smtp-burst")
+            code, _ = smtp.mail("relaytest@example.com")
+            if code >= 400:
+                return False
+            code, _ = smtp.rcpt("recipient@example.net")
+            return code < 400
+    except Exception:  # pragma: no cover - network failures
+        return False
+
+
+def blacklist_check(ip: str, zones: List[str]) -> Dict[str, str]:
+    """Return mapping of RBL zone to listing status for ``ip``."""
+    results: Dict[str, str] = {}
+    try:
+        ip_obj = ipaddress.ip_address(ip)
+    except ValueError as exc:  # pragma: no cover - input validation
+        return {zone: f"error: {exc}" for zone in zones}
+
+    if ip_obj.version == 4:
+        reversed_ip = ".".join(reversed(ip.split(".")))
+    else:  # pragma: no cover - IPv6 rarely used in tests
+        reversed_ip = ".".join(reversed(ip_obj.exploded.split(":")))
+
+    for zone in zones:
+        qname = f"{reversed_ip}.{zone}"
+        try:
+            resolver.resolve(qname, "A")
+            results[zone] = "listed"
+        except resolver.NXDOMAIN:
+            results[zone] = "not listed"
+        except Exception as exc:  # pragma: no cover - resolver errors
+            results[zone] = f"error: {exc}"
+    return results

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -82,22 +82,22 @@ def test_per_burst_flag():
 def test_discovery_options():
     args = burst_cli.parse_args([
         '--check-dmarc', 'ex.com',
-        '--ping', 'host'
+        '--ping-test', 'host'
     ], Config())
     assert args.check_dmarc == 'ex.com'
-    assert args.ping == 'host'
+    assert args.ping_test == 'host'
 
 
-def test_check_rbl_option():
+def test_blacklist_option():
     args = burst_cli.parse_args([
-        '--check-rbl', '1.2.3.4', 'rbl.example'
+        '--blacklist-check', '1.2.3.4', 'rbl.example'
     ], Config())
-    assert args.check_rbl == ['1.2.3.4', 'rbl.example']
+    assert args.blacklist_check == ['1.2.3.4', 'rbl.example']
 
 
-def test_test_open_relay_flag():
-    args = burst_cli.parse_args(['--test-open-relay'], Config())
-    assert args.test_open_relay
+def test_open_relay_flag():
+    args = burst_cli.parse_args(['--open-relay-test'], Config())
+    assert args.open_relay_test
 
 
 def test_logging_cli_flags():

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from smtpburst import discovery
+from smtpburst import discovery, nettests
 
 
 class DummyAns:
@@ -38,8 +38,8 @@ def test_ping(monkeypatch):
         assert cmd[-1] == 'host'
         return SimpleNamespace(stdout='pong')
 
-    monkeypatch.setattr(discovery.subprocess, 'run', fake_run)
-    assert discovery.ping('host') == 'pong'
+    monkeypatch.setattr(nettests.subprocess, 'run', fake_run)
+    assert nettests.ping('host') == 'pong'
 
 
 def test_traceroute(monkeypatch):
@@ -47,8 +47,8 @@ def test_traceroute(monkeypatch):
         assert cmd[-1] == 'host'
         return SimpleNamespace(stdout='trace')
 
-    monkeypatch.setattr(discovery.subprocess, 'run', fake_run)
-    assert discovery.traceroute('host') == 'trace'
+    monkeypatch.setattr(nettests.subprocess, 'run', fake_run)
+    assert nettests.traceroute('host') == 'trace'
 
 
 def test_check_rbl(monkeypatch):
@@ -60,13 +60,13 @@ def test_check_rbl(monkeypatch):
             return [DummyAns('127.0.0.2')]
         raise discovery.resolver.NXDOMAIN
 
-    monkeypatch.setattr(discovery.resolver, 'resolve', fake_resolve)
-    res = discovery.check_rbl('1.2.3.4', ['listed.example', 'clean.example'])
+    monkeypatch.setattr(nettests.resolver, 'resolve', fake_resolve)
+    res = nettests.blacklist_check('1.2.3.4', ['listed.example', 'clean.example'])
     assert res == {'listed.example': 'listed', 'clean.example': 'not listed'}
     assert calls == ['4.3.2.1.listed.example', '4.3.2.1.clean.example']
 
 
-def test_test_open_relay(monkeypatch):
+def test_open_relay_test(monkeypatch):
     class DummySMTP:
         def __init__(self, *args, **kwargs):
             pass
@@ -86,5 +86,5 @@ def test_test_open_relay(monkeypatch):
         def __exit__(self, exc_type, exc, tb):
             pass
 
-    monkeypatch.setattr(discovery.smtplib, 'SMTP', DummySMTP)
-    assert discovery.test_open_relay('host')
+    monkeypatch.setattr(nettests.smtplib, 'SMTP', DummySMTP)
+    assert nettests.open_relay_test('host')


### PR DESCRIPTION
## Summary
- add `nettests` module with ping, traceroute, open relay and blacklist checks
- expose new CLI flags for these network tests
- wire main entry to call into nettests
- update `__init__` and unit tests

## Testing
- `pip install dnspython`
- `pip install pyyaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685be48cf0bc8325a9f617113fcbd7cc