### PR TITLE
Warn on unknown config options

### DIFF
--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import warnings
 from typing import Any, Dict
 
 from .config import Config
@@ -95,5 +96,12 @@ def parse_args(args=None, cfg: Config | None = None) -> argparse.Namespace:
             config_data = load_config(config_args.config)
         except FileNotFoundError:
             raise SystemExit(f"Config file not found: {config_args.config}")
+        known = {action.dest for action in parser._actions}
+        unknown = [k for k in config_data.keys() if k not in known]
+        if unknown:
+            warnings.warn(
+                f"Unknown config options: {', '.join(unknown)}",
+                RuntimeWarning,
+            )
         parser.set_defaults(**config_data)
     return parser.parse_args(args)

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -107,3 +108,10 @@ def test_logging_cli_flags():
     assert args.errors_only
     args = burst_cli.parse_args(['--warnings'], Config())
     assert args.warnings
+
+
+def test_unknown_config_warning(tmp_path):
+    cfg_path = tmp_path / "u.json"
+    cfg_path.write_text(json.dumps({"bogus": 1}))
+    with pytest.warns(RuntimeWarning):
+        burst_cli.parse_args(["--config", str(cfg_path)], Config())


### PR DESCRIPTION
## Summary
- warn about unknown options in config files
- test that warnings are triggered for unknown config keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685be8d2e67883258c2b191b30850eb5