### PR TITLE
Implement network discovery utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,8 @@ Simple python script that sends smtp email in bursts using independent processes
 - Customizable subject and message body via CLI options
 - Autonomous bombing mode for hands-off bursts
 - Helper scripts for packaging and running tests
+- Discovery utilities for MX lookup, SMTP extension scan, certificate checks,
+  port scanning and honeypot probing
 
 ## Installation
 
@@ -59,6 +61,11 @@ Additional CLI flags provide extended functionality:
 - `--check-srv NAME` query SRV record for NAME
 - `--check-soa DOMAIN` query SOA record for DOMAIN
 - `--check-txt DOMAIN` query TXT record for DOMAIN
+- `--lookup-mx DOMAIN` lookup MX records for DOMAIN
+- `--smtp-extensions HOST` list SMTP extensions for HOST
+- `--cert-check HOST` retrieve TLS certificate from HOST
+- `--port-scan HOST PORT [PORT ...]` scan ports on HOST
+- `--probe-honeypot HOST` probe HOST for SMTP honeypot
 - `--blacklist-check IP ZONE [ZONE ...]` check IP against DNSBL zones
 - `--open-relay-test` test if the target SMTP server is an open relay
 - `--ping-test HOST` run ping for HOST
@@ -91,7 +98,8 @@ The following flags perform DNS and network checks using the utilities in
 `smtpburst.discovery` and `smtpburst.nettests`:
 
 - `--check-dmarc`, `--check-spf`, `--check-dkim`
-- `--check-srv`, `--check-soa`, `--check-txt`
+- `--check-srv`, `--check-soa`, `--check-txt`, `--lookup-mx`
+- `--smtp-extensions`, `--cert-check`, `--port-scan`, `--probe-honeypot`
 - `--blacklist-check`
 - `--open-relay-test`, `--ping-test`, `--traceroute-test`
 

--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -83,6 +83,21 @@ def main(argv=None):
         results['soa'] = discovery.check_soa(args.check_soa)
     if args.check_txt:
         results['txt'] = discovery.check_txt(args.check_txt)
+    if args.lookup_mx:
+        results['mx'] = discovery.lookup_mx(args.lookup_mx)
+    if args.smtp_extensions:
+        host, port = send.parse_server(args.smtp_extensions)
+        results['smtp_extensions'] = discovery.smtp_extensions(host, port)
+    if args.cert_check:
+        host, port = send.parse_server(args.cert_check)
+        results['certificate'] = discovery.check_certificate(host, port)
+    if args.port_scan:
+        host = args.port_scan[0]
+        ports = [int(p) for p in args.port_scan[1:]]
+        results['port_scan'] = discovery.port_scan(host, ports)
+    if args.probe_honeypot:
+        host, port = send.parse_server(args.probe_honeypot)
+        results['honeypot'] = discovery.probe_honeypot(host, port)
     if args.blacklist_check:
         results['blacklist'] = nettests.blacklist_check(
             args.blacklist_check[0], args.blacklist_check[1:]

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -62,6 +62,15 @@ def build_parser(cfg: Config) -> argparse.ArgumentParser:
     parser.add_argument("--check-srv", help="Service to query SRV record for")
     parser.add_argument("--check-soa", help="Domain to query SOA record for")
     parser.add_argument("--check-txt", help="Domain to query TXT record for")
+    parser.add_argument("--lookup-mx", help="Domain to query MX records for")
+    parser.add_argument("--smtp-extensions", help="Host to discover SMTP extensions")
+    parser.add_argument("--cert-check", help="Host to retrieve TLS certificate from")
+    parser.add_argument(
+        "--port-scan",
+        nargs="+",
+        help="Host followed by one or more ports to scan",
+    )
+    parser.add_argument("--probe-honeypot", help="Host to probe for SMTP honeypot")
     parser.add_argument(
         "--blacklist-check",
         nargs="+",

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -101,6 +101,21 @@ def test_open_relay_flag():
     assert args.open_relay_test
 
 
+def test_new_discovery_cli_options():
+    args = burst_cli.parse_args([
+        '--lookup-mx', 'example.com',
+        '--smtp-extensions', 'host',
+        '--cert-check', 'host',
+        '--port-scan', 'host', '25', '587',
+        '--probe-honeypot', 'host'
+    ], Config())
+    assert args.lookup_mx == 'example.com'
+    assert args.smtp_extensions == 'host'
+    assert args.cert_check == 'host'
+    assert args.port_scan == ['host', '25', '587']
+    assert args.probe_honeypot == 'host'
+
+
 def test_logging_cli_flags():
     args = burst_cli.parse_args(['--silent'], Config())
     assert args.silent


### PR DESCRIPTION
## Summary
- add new network discovery helpers like MX lookup and port scanning
- expose discovery helpers through CLI options
- support collecting results from main entry point
- document new features and CLI options
- test additional CLI flags and discovery routines

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685bf12229a08325a42486d364bb6e01