### PR TITLE
Skip YAML test if PyYAML missing

### DIFF
--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -28,6 +28,7 @@ def test_cli_overrides_config(tmp_path):
     assert args.server == "cli.example.com"
 
 
+@pytest.mark.skipif(burst_cli.yaml is None, reason="PyYAML not installed")
 def test_yaml_config_parsing(tmp_path):
     yaml_cfg = "server: yaml.example.com\n"
     cfg_path = tmp_path / "config.yaml"


### PR DESCRIPTION
## Summary
- mark YAML config parsing test to skip when PyYAML isn't installed

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bf426cf1c83259365c59f64e456d5