### PR TITLE
Add inbox support for IMAP/POP3 verification

### DIFF
--- a/smtpburst/__init__.py
+++ b/smtpburst/__init__.py
@@ -1,6 +1,6 @@
 """smtp-burst library package."""
 
-from . import send, config, cli, datagen, attacks, report, discovery, nettests
+from . import send, config, cli, datagen, attacks, report, discovery, nettests, inbox
 
 __all__ = [
     "send",
@@ -11,4 +11,5 @@ __all__ = [
     "report",
     "discovery",
     "nettests",
+    "inbox",
 ]

--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -4,7 +4,7 @@ import logging
 from smtpburst.config import Config
 from smtpburst import send
 from smtpburst import cli
-from smtpburst import discovery, nettests
+from smtpburst import discovery, nettests, inbox
 from smtpburst import report
 
 logger = logging.getLogger(__name__)
@@ -98,6 +98,14 @@ def main(argv=None):
     if args.probe_honeypot:
         host, port = send.parse_server(args.probe_honeypot)
         results['honeypot'] = discovery.probe_honeypot(host, port)
+    if args.imap_check:
+        host, user, pwd, crit = args.imap_check
+        host, port = send.parse_server(host)
+        results['imap'] = inbox.imap_search(host, user, pwd, criteria=crit, port=port)
+    if args.pop3_check:
+        host, user, pwd, patt = args.pop3_check
+        host, port = send.parse_server(host)
+        results['pop3'] = inbox.pop3_search(host, user, pwd, pattern=patt.encode(), port=port)
     if args.blacklist_check:
         results['blacklist'] = nettests.blacklist_check(
             args.blacklist_check[0], args.blacklist_check[1:]

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -77,6 +77,18 @@ def build_parser(cfg: Config) -> argparse.ArgumentParser:
         help="IP followed by one or more DNSBL zones to query",
     )
     parser.add_argument(
+        "--imap-check",
+        nargs=4,
+        metavar=("HOST", "USER", "PASS", "CRITERIA"),
+        help="Check IMAP inbox for messages matching CRITERIA",
+    )
+    parser.add_argument(
+        "--pop3-check",
+        nargs=4,
+        metavar=("HOST", "USER", "PASS", "PATTERN"),
+        help="Check POP3 inbox for messages containing PATTERN",
+    )
+    parser.add_argument(
         "--open-relay-test",
         action="store_true",
         help="Test if the target SMTP server is an open relay",

--- a/smtpburst/inbox.py
+++ b/smtpburst/inbox.py
@@ -1,0 +1,54 @@
+import imaplib
+import poplib
+from typing import List
+
+
+def imap_search(
+    host: str,
+    user: str,
+    password: str,
+    *,
+    criteria: str = "ALL",
+    port: int = 993,
+    ssl: bool = True,
+    mailbox: str = "INBOX",
+) -> List[bytes]:
+    """Return message IDs matching ``criteria`` from IMAP server."""
+    cls = imaplib.IMAP4_SSL if ssl else imaplib.IMAP4
+    with cls(host, port) as imap:
+        imap.login(user, password)
+        imap.select(mailbox)
+        typ, data = imap.search(None, criteria)
+        if typ != "OK" or not data:
+            return []
+        return data[0].split()
+
+
+def pop3_search(
+    host: str,
+    user: str,
+    password: str,
+    *,
+    pattern: bytes | None = None,
+    port: int = 995,
+    ssl: bool = True,
+) -> List[int]:
+    """Return message numbers containing ``pattern`` via POP3."""
+    cls = poplib.POP3_SSL if ssl else poplib.POP3
+    pop = cls(host, port)
+    try:
+        pop.user(user)
+        pop.pass_(password)
+        ids: List[int] = []
+        count = len(pop.list()[1])
+        for i in range(1, count + 1):
+            resp, lines, _ = pop.retr(i)
+            msg = b"\n".join(lines)
+            if pattern is None or pattern in msg:
+                ids.append(i)
+        return ids
+    finally:
+        try:
+            pop.quit()
+        except Exception:
+            pass

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -117,6 +117,15 @@ def test_new_discovery_cli_options():
     assert args.probe_honeypot == 'host'
 
 
+def test_inbox_cli_options():
+    args = burst_cli.parse_args([
+        '--imap-check', 'h', 'u', 'p', 'ALL',
+        '--pop3-check', 'p', 'u2', 'p2', 'txt'
+    ], Config())
+    assert args.imap_check == ['h', 'u', 'p', 'ALL']
+    assert args.pop3_check == ['p', 'u2', 'p2', 'txt']
+
+
 def test_logging_cli_flags():
     args = burst_cli.parse_args(['--silent'], Config())
     assert args.silent

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -1,0 +1,51 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from smtpburst import inbox
+
+
+def test_imap_search(monkeypatch):
+    class DummyIMAP:
+        def __init__(self, host, port):
+            assert host == 'host'
+            assert port == 993
+        def login(self, user, pwd):
+            assert user == 'u'
+            assert pwd == 'p'
+        def select(self, mbox):
+            assert mbox == 'INBOX'
+        def search(self, charset, criteria):
+            assert charset is None
+            assert criteria == 'ALL'
+            return ('OK', [b'1 2'])
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(inbox.imaplib, 'IMAP4_SSL', DummyIMAP)
+    ids = inbox.imap_search('host', 'u', 'p')
+    assert ids == [b'1', b'2']
+
+
+def test_pop3_search(monkeypatch):
+    class DummyPOP:
+        def __init__(self, host, port):
+            assert host == 'host'
+            assert port == 995
+            self.msgs = {1: b'abc', 2: b'def abc'}
+        def user(self, u):
+            assert u == 'u'
+        def pass_(self, p):
+            assert p == 'p'
+        def list(self):
+            return (b'+OK', [b'1 0', b'2 0'])
+        def retr(self, i):
+            data = self.msgs[i].split(b'\n')
+            return (b'+OK', [self.msgs[i]], len(self.msgs[i]))
+        def quit(self):
+            pass
+    monkeypatch.setattr(inbox.poplib, 'POP3_SSL', DummyPOP)
+    ids = inbox.pop3_search('host', 'u', 'p', pattern=b'abc')
+    assert ids == [1, 2]


### PR DESCRIPTION
## Summary
- support IMAP and POP3 backscatter checks
- add optional `--imap-check` and `--pop3-check` flags
- integrate inbox checking in `__main__`
- expose new `inbox` module
- test inbox functionality and CLI parsing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685bf8dd2e68832581daeabea7124a35