### PR TITLE
Add TLS version discovery

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,7 @@ Additional CLI flags provide extended functionality:
 - `--cert-check HOST` retrieve TLS certificate from HOST
 - `--port-scan HOST PORT [PORT ...]` scan ports on HOST
 - `--probe-honeypot HOST` probe HOST for SMTP honeypot
+- `--tls-discovery HOST` discover supported TLS versions on HOST
 - `--blacklist-check IP ZONE [ZONE ...]` check IP against DNSBL zones
 - `--open-relay-test` test if the target SMTP server is an open relay
 - `--ping-test HOST` run ping for HOST
@@ -89,6 +90,17 @@ ping              : 64 bytes from 127.0.0.1
 +-----------------+
 ```
 
+Running TLS discovery prints the supported versions:
+
+```
+$ python -m smtpburst --tls-discovery smtp.example.com
++-----------------+
+| Test Report     |
++-----------------+
+tls               : {'TLSv1': False, 'TLSv1_2': True}
++-----------------+
+```
+
 Results are printed to standard output and can be redirected to a file if
 required.
 
@@ -99,7 +111,8 @@ The following flags perform DNS and network checks using the utilities in
 
 - `--check-dmarc`, `--check-spf`, `--check-dkim`
 - `--check-srv`, `--check-soa`, `--check-txt`, `--lookup-mx`
-- `--smtp-extensions`, `--cert-check`, `--port-scan`, `--probe-honeypot`
+- `--smtp-extensions`, `--cert-check`, `--port-scan`, `--probe-honeypot`,
+  `--tls-discovery`
 - `--blacklist-check`
 - `--open-relay-test`, `--ping-test`, `--traceroute-test`
 

--- a/smtpburst/__init__.py
+++ b/smtpburst/__init__.py
@@ -1,6 +1,6 @@
 """smtp-burst library package."""
 
-from . import send, config, cli, datagen, attacks, report, discovery, nettests, inbox
+from . import send, config, cli, datagen, attacks, report, discovery, nettests, inbox, tls_probe
 
 __all__ = [
     "send",
@@ -12,4 +12,5 @@ __all__ = [
     "discovery",
     "nettests",
     "inbox",
+    "tls_probe",
 ]

--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -98,6 +98,10 @@ def main(argv=None):
     if args.probe_honeypot:
         host, port = send.parse_server(args.probe_honeypot)
         results['honeypot'] = discovery.probe_honeypot(host, port)
+    if args.tls_discovery:
+        host, port = send.parse_server(args.tls_discovery)
+        from . import tls_probe
+        results['tls'] = tls_probe.discover(host, port)
     if args.imap_check:
         host, user, pwd, crit = args.imap_check
         host, port = send.parse_server(host)

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -72,6 +72,10 @@ def build_parser(cfg: Config) -> argparse.ArgumentParser:
     )
     parser.add_argument("--probe-honeypot", help="Host to probe for SMTP honeypot")
     parser.add_argument(
+        "--tls-discovery",
+        help="Host to discover supported TLS versions",
+    )
+    parser.add_argument(
         "--blacklist-check",
         nargs="+",
         help="IP followed by one or more DNSBL zones to query",

--- a/smtpburst/tls_probe.py
+++ b/smtpburst/tls_probe.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""TLS version discovery utilities."""
+
+from typing import Dict
+import socket
+import ssl
+
+
+VERSIONS = {
+    "TLSv1": ssl.TLSVersion.TLSv1,
+    "TLSv1_1": ssl.TLSVersion.TLSv1_1,
+    "TLSv1_2": ssl.TLSVersion.TLSv1_2,
+    "TLSv1_3": ssl.TLSVersion.TLSv1_3,
+}
+
+
+def discover(host: str, port: int = 443, timeout: float = 3.0) -> Dict[str, bool]:
+    """Return mapping of TLS version names to connection success."""
+    results: Dict[str, bool] = {}
+    for name, version in VERSIONS.items():
+        context = ssl.create_default_context()
+        context.minimum_version = version
+        context.maximum_version = version
+        try:
+            sock = socket.socket()
+            sock.settimeout(timeout)
+            with context.wrap_socket(sock, server_hostname=host) as s:
+                s.connect((host, port))
+            results[name] = True
+        except Exception:
+            results[name] = False
+    return results

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -117,6 +117,13 @@ def test_new_discovery_cli_options():
     assert args.probe_honeypot == 'host'
 
 
+def test_tls_discovery_option():
+    args = burst_cli.parse_args([
+        '--tls-discovery', 'host'
+    ], Config())
+    assert args.tls_discovery == 'host'
+
+
 def test_inbox_cli_options():
     args = burst_cli.parse_args([
         '--imap-check', 'h', 'u', 'p', 'ALL',

--- a/tests/test_tls_probe.py
+++ b/tests/test_tls_probe.py
@@ -1,0 +1,38 @@
+import ssl
+from smtpburst import tls_probe
+
+
+def test_tls_discover(monkeypatch):
+    class DummyRaw:
+        def settimeout(self, t):
+            pass
+    def fake_socket():
+        return DummyRaw()
+
+    class DummyCtx:
+        def __init__(self):
+            self.minimum_version = None
+            self.maximum_version = None
+        def wrap_socket(self, sock, server_hostname=None):
+            ver = self.maximum_version
+            class DummySock:
+                def __enter__(self_inner):
+                    return self_inner
+                def __exit__(self_inner, exc_type, exc, tb):
+                    pass
+                def connect(self_inner, addr):
+                    if ver == ssl.TLSVersion.TLSv1_2:
+                        return
+                    raise OSError('fail')
+            return DummySock()
+    def fake_ctx_factory():
+        return DummyCtx()
+
+    monkeypatch.setattr(tls_probe.socket, 'socket', fake_socket)
+    monkeypatch.setattr(tls_probe.ssl, 'create_default_context', fake_ctx_factory)
+
+    res = tls_probe.discover('h')
+    assert res['TLSv1'] is False
+    assert res['TLSv1_1'] is False
+    assert res['TLSv1_2'] is True
+    assert res['TLSv1_3'] is False


### PR DESCRIPTION
## Summary
- add TLS version probing utilities
- support `--tls-discovery` CLI flag
- report TLS results in main program
- document TLS discovery usage
- test TLS probing and CLI handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bfbbca1348325b2167e2631a4f1a8