### PR TITLE
Add SSL discovery utility

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,7 @@ Additional CLI flags provide extended functionality:
 - `--port-scan HOST PORT [PORT ...]` scan ports on HOST
 - `--probe-honeypot HOST` probe HOST for SMTP honeypot
 - `--tls-discovery HOST` discover supported TLS versions on HOST
+- `--ssl-discovery HOST` discover supported legacy SSL versions on HOST
 - `--blacklist-check IP ZONE [ZONE ...]` check IP against DNSBL zones
 - `--open-relay-test` test if the target SMTP server is an open relay
 - `--ping-test HOST` run ping for HOST
@@ -101,6 +102,17 @@ tls               : {'TLSv1': False, 'TLSv1_2': True}
 +-----------------+
 ```
 
+Running legacy SSL discovery works similarly:
+
+```
+$ python -m smtpburst --ssl-discovery smtp.example.com
++-----------------+
+| Test Report     |
++-----------------+
+ssl               : {'SSLv3': False}
++-----------------+
+```
+
 Results are printed to standard output and can be redirected to a file if
 required.
 
@@ -112,7 +124,7 @@ The following flags perform DNS and network checks using the utilities in
 - `--check-dmarc`, `--check-spf`, `--check-dkim`
 - `--check-srv`, `--check-soa`, `--check-txt`, `--lookup-mx`
 - `--smtp-extensions`, `--cert-check`, `--port-scan`, `--probe-honeypot`,
-  `--tls-discovery`
+  `--tls-discovery`, `--ssl-discovery`
 - `--blacklist-check`
 - `--open-relay-test`, `--ping-test`, `--traceroute-test`
 

--- a/smtpburst/__init__.py
+++ b/smtpburst/__init__.py
@@ -1,6 +1,6 @@
 """smtp-burst library package."""
 
-from . import send, config, cli, datagen, attacks, report, discovery, nettests, inbox, tls_probe
+from . import send, config, cli, datagen, attacks, report, discovery, nettests, inbox, tls_probe, ssl_probe
 
 __all__ = [
     "send",
@@ -13,4 +13,5 @@ __all__ = [
     "nettests",
     "inbox",
     "tls_probe",
+    "ssl_probe",
 ]

--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -102,6 +102,10 @@ def main(argv=None):
         host, port = send.parse_server(args.tls_discovery)
         from . import tls_probe
         results['tls'] = tls_probe.discover(host, port)
+    if args.ssl_discovery:
+        host, port = send.parse_server(args.ssl_discovery)
+        from . import ssl_probe
+        results['ssl'] = ssl_probe.discover(host, port)
     if args.imap_check:
         host, user, pwd, crit = args.imap_check
         host, port = send.parse_server(host)

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -76,6 +76,10 @@ def build_parser(cfg: Config) -> argparse.ArgumentParser:
         help="Host to discover supported TLS versions",
     )
     parser.add_argument(
+        "--ssl-discovery",
+        help="Host to discover supported legacy SSL versions",
+    )
+    parser.add_argument(
         "--blacklist-check",
         nargs="+",
         help="IP followed by one or more DNSBL zones to query",

--- a/smtpburst/ssl_probe.py
+++ b/smtpburst/ssl_probe.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+"""Legacy SSL version discovery utilities."""
+
+from typing import Dict
+import socket
+import ssl
+
+VERSIONS = {
+    "SSLv3": ssl.TLSVersion.SSLv3,
+}
+
+
+def discover(host: str, port: int = 443, timeout: float = 3.0) -> Dict[str, bool]:
+    """Return mapping of SSL version names to connection success."""
+    results: Dict[str, bool] = {}
+    for name, version in VERSIONS.items():
+        context = ssl.create_default_context()
+        context.minimum_version = version
+        context.maximum_version = version
+        try:
+            sock = socket.socket()
+            sock.settimeout(timeout)
+            with context.wrap_socket(sock, server_hostname=host) as s:
+                s.connect((host, port))
+            results[name] = True
+        except Exception:
+            results[name] = False
+    return results

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -124,6 +124,13 @@ def test_tls_discovery_option():
     assert args.tls_discovery == 'host'
 
 
+def test_ssl_discovery_option():
+    args = burst_cli.parse_args([
+        '--ssl-discovery', 'host'
+    ], Config())
+    assert args.ssl_discovery == 'host'
+
+
 def test_inbox_cli_options():
     args = burst_cli.parse_args([
         '--imap-check', 'h', 'u', 'p', 'ALL',

--- a/tests/test_ssl_probe.py
+++ b/tests/test_ssl_probe.py
@@ -1,0 +1,42 @@
+import ssl
+from smtpburst import ssl_probe
+
+
+def test_ssl_discover(monkeypatch):
+    class DummyRaw:
+        def settimeout(self, t):
+            pass
+
+    def fake_socket():
+        return DummyRaw()
+
+    class DummyCtx:
+        def __init__(self):
+            self.minimum_version = None
+            self.maximum_version = None
+
+        def wrap_socket(self, sock, server_hostname=None):
+            ver = self.maximum_version
+
+            class DummySock:
+                def __enter__(self_inner):
+                    return self_inner
+
+                def __exit__(self_inner, exc_type, exc, tb):
+                    pass
+
+                def connect(self_inner, addr):
+                    if ver == ssl.TLSVersion.SSLv3:
+                        return
+                    raise OSError('fail')
+
+            return DummySock()
+
+    def fake_ctx_factory():
+        return DummyCtx()
+
+    monkeypatch.setattr(ssl_probe.socket, 'socket', fake_socket)
+    monkeypatch.setattr(ssl_probe.ssl, 'create_default_context', fake_ctx_factory)
+
+    res = ssl_probe.discover('h')
+    assert res['SSLv3'] is True


### PR DESCRIPTION
## Summary
- include `ssl_probe` package for legacy SSL version scanning
- expose new `--ssl-discovery` CLI option
- integrate SSL discovery in main entry point
- document SSL discovery usage
- test the new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bfd20aa248325a8b52a2c813ea154