### PR TITLE
Add rDNS verification utility

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@ Additional CLI flags provide extended functionality:
 - `--open-relay-test` test if the target SMTP server is an open relay
 - `--ping-test HOST` run ping for HOST
 - `--traceroute-test HOST` run traceroute to HOST
+- `--rdns-test` verify reverse DNS for the configured server
 - `--silent` suppress all output
 - `--errors-only` show only error messages
 - `--warnings` show warnings and errors only
@@ -131,7 +132,7 @@ The following flags perform DNS and network checks using the utilities in
 - `--smtp-extensions`, `--cert-check`, `--port-scan`, `--probe-honeypot`,
   `--tls-discovery`, `--ssl-discovery`
 - `--blacklist-check`
-- `--open-relay-test`, `--ping-test`, `--traceroute-test`
+- `--open-relay-test`, `--ping-test`, `--traceroute-test`, `--rdns-test`
 
 When these options are used, the report shown above is generated.
 

--- a/smtpburst/__init__.py
+++ b/smtpburst/__init__.py
@@ -1,6 +1,6 @@
 """smtp-burst library package."""
 
-from . import send, config, cli, datagen, attacks, report, discovery, nettests, inbox, tls_probe, ssl_probe
+from . import send, config, cli, datagen, attacks, report, discovery, nettests, inbox, tls_probe, ssl_probe, rdns
 
 __all__ = [
     "send",
@@ -14,4 +14,5 @@ __all__ = [
     "inbox",
     "tls_probe",
     "ssl_probe",
+    "rdns",
 ]

--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -128,6 +128,12 @@ def main(argv=None):
         results['ping'] = nettests.ping(args.ping_test)
     if args.traceroute_test:
         results['traceroute'] = nettests.traceroute(args.traceroute_test)
+    if args.rdns_test:
+        host, _ = send.parse_server(args.server)
+        from . import rdns
+        ok = rdns.verify(host)
+        msg = "Reverse DNS: PASS" if ok else "Reverse DNS: FAIL"
+        print(msg)
     if results:
         logger.info(report.ascii_report(results))
 

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -106,6 +106,11 @@ def build_parser(cfg: Config) -> argparse.ArgumentParser:
     )
     parser.add_argument("--ping-test", help="Host to ping")
     parser.add_argument("--traceroute-test", help="Host to traceroute")
+    parser.add_argument(
+        "--rdns-test",
+        action="store_true",
+        help="Verify reverse DNS for the configured server",
+    )
     level_group = parser.add_mutually_exclusive_group()
     level_group.add_argument("--silent", action="store_true", help="Suppress all log output")
     level_group.add_argument("--errors-only", action="store_true", help="Show only error messages")

--- a/smtpburst/rdns.py
+++ b/smtpburst/rdns.py
@@ -1,0 +1,16 @@
+"""Reverse DNS verification utilities."""
+
+from __future__ import annotations
+
+import socket
+
+
+def verify(host: str) -> bool:
+    """Return ``True`` if the PTR record for ``host`` resolves back to the same IP."""
+    try:
+        ip = socket.gethostbyname(host)
+        ptr, _, _ = socket.gethostbyaddr(ip)
+        forward_ip = socket.gethostbyname(ptr)
+        return forward_ip == ip
+    except Exception:  # pragma: no cover - network failures
+        return False

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -160,6 +160,11 @@ def test_logging_cli_flags():
     assert args.warnings
 
 
+def test_rdns_flag():
+    args = burst_cli.parse_args(['--rdns-test'], Config())
+    assert args.rdns_test
+
+
 def test_unknown_config_warning(tmp_path):
     cfg_path = tmp_path / "u.json"
     cfg_path.write_text(json.dumps({"bogus": 1}))

--- a/tests/test_rdns.py
+++ b/tests/test_rdns.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from smtpburst import rdns
+
+
+def test_verify_rdns_success(monkeypatch):
+    def fake_gethostbyname(host):
+        return '1.2.3.4'
+
+    def fake_gethostbyaddr(ip):
+        assert ip == '1.2.3.4'
+        return ('mail.example.com', [], [ip])
+
+    monkeypatch.setattr(rdns.socket, 'gethostbyname', fake_gethostbyname)
+    monkeypatch.setattr(rdns.socket, 'gethostbyaddr', fake_gethostbyaddr)
+
+    assert rdns.verify('example.com')
+
+
+def test_verify_rdns_failure(monkeypatch):
+    def fake_gethostbyname(host):
+        if host == 'example.com':
+            return '1.2.3.4'
+        return '5.6.7.8'
+
+    def fake_gethostbyaddr(ip):
+        return ('other.example.com', [], [ip])
+
+    monkeypatch.setattr(rdns.socket, 'gethostbyname', fake_gethostbyname)
+    monkeypatch.setattr(rdns.socket, 'gethostbyaddr', fake_gethostbyaddr)
+
+    assert not rdns.verify('example.com')
+


### PR DESCRIPTION
## Summary
- add new `smtpburst.rdns` module for reverse DNS checks
- expose `--rdns-test` CLI flag to verify rDNS for the configured server
- print a simple PASS/FAIL message during execution
- document the option in the README
- add unit tests for the new module and CLI flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c091d7ac083258f25e07bdd6da2cd