### PR TITLE
Fix CI artifact upload version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           ./scripts/package.sh
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: smtp-burst-artifacts
           path: dist/


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to use `actions/upload-artifact@v4`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0b42a8f8832585b5db74e211b058