### PR TITLE
Add proxy ordering and validation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,8 @@ Additional CLI flags provide extended functionality:
 
 - `--open-sockets N` open N connections without sending email
 - `--proxy-file FILE` rotate through SOCKS proxies in FILE
+- `--proxy-order {asc,desc,random}` apply proxies in given order
+- `--check-proxies` validate proxies before use
 - `--userlist FILE` username wordlist for SMTP AUTH
 - `--passlist FILE` password wordlist for SMTP AUTH
 - `--template-file FILE` phishing template with `{sender}` tags

--- a/smtpburst/__init__.py
+++ b/smtpburst/__init__.py
@@ -13,6 +13,7 @@ from . import (
     tls_probe,
     ssl_probe,
     rdns,
+    proxy,
 )
 
 __all__ = [
@@ -28,4 +29,5 @@ __all__ = [
     "tls_probe",
     "ssl_probe",
     "rdns",
+    "proxy",
 ]

--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -61,8 +61,15 @@ def main(argv=None):
         cfg.SB_RAND_STREAM = open(args.rand_stream, "rb")
 
     if args.proxy_file:
-        with open(args.proxy_file, "r", encoding="utf-8") as fh:
-            cfg.SB_PROXIES = [line.strip() for line in fh if line.strip()]
+        from . import proxy
+
+        cfg.SB_PROXIES = proxy.load_proxies(
+            args.proxy_file,
+            order=args.proxy_order,
+            check=args.check_proxies,
+        )
+    cfg.SB_PROXY_ORDER = args.proxy_order
+    cfg.SB_CHECK_PROXIES = args.check_proxies
     if args.userlist:
         with open(args.userlist, "r", encoding="utf-8") as fh:
             cfg.SB_USERLIST = [line.strip() for line in fh if line.strip()]

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -173,6 +173,18 @@ def build_parser(cfg: Config) -> argparse.ArgumentParser:
     parser.add_argument(
         "--proxy-file", help="File containing SOCKS proxies to rotate through"
     )
+    parser.add_argument(
+        "--proxy-order",
+        choices=["asc", "desc", "random"],
+        default=cfg.SB_PROXY_ORDER,
+        help="Order to apply proxies",
+    )
+    parser.add_argument(
+        "--check-proxies",
+        action="store_true",
+        default=cfg.SB_CHECK_PROXIES,
+        help="Validate proxies before use",
+    )
     parser.add_argument("--userlist", help="Username wordlist for SMTP AUTH")
     parser.add_argument("--passlist", help="Password wordlist for SMTP AUTH")
     parser.add_argument("--template-file", help="Phishing template file")

--- a/smtpburst/config.py
+++ b/smtpburst/config.py
@@ -29,6 +29,8 @@ class Config:
 
     # Proxy and authentication defaults
     SB_PROXIES: List[str] = field(default_factory=list)
+    SB_PROXY_ORDER: str = "asc"
+    SB_CHECK_PROXIES: bool = False
     SB_USERLIST: List[str] = field(default_factory=list)
     SB_PASSLIST: List[str] = field(default_factory=list)
 

--- a/smtpburst/proxy.py
+++ b/smtpburst/proxy.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Utilities for handling SOCKS proxies."""
+
+import random
+import socket
+from typing import List
+
+from .nettests import ping
+from .send import parse_server
+
+
+def check_proxy(proxy: str, host: str = "example.com", port: int = 80) -> bool:
+    """Return ``True`` if ``proxy`` appears reachable.
+
+    A basic validation is performed using ping, DNS resolution and a TCP
+    handshake to ``proxy`` followed by an optional HTTP CONNECT request.
+    """
+    ph, pp = parse_server(proxy)
+
+    if not ping(ph):
+        return False
+    try:
+        socket.gethostbyname(ph)
+    except Exception:
+        return False
+
+    try:
+        with socket.create_connection((ph, pp), timeout=5) as sock:
+            request = f"CONNECT {host}:{port} HTTP/1.1\r\n\r\n".encode()
+            try:
+                sock.sendall(request)
+                sock.recv(1)
+            except Exception:
+                return False
+    except Exception:
+        return False
+    return True
+
+
+def load_proxies(path: str, order: str = "asc", check: bool = False) -> List[str]:
+    """Return list of proxies from ``path`` respecting ``order``.
+
+    If ``check`` is True, invalid proxies are filtered out using
+    :func:`check_proxy`.
+    """
+    with open(path, "r", encoding="utf-8") as fh:
+        proxies = [line.strip() for line in fh if line.strip()]
+
+    if order == "desc":
+        proxies = list(reversed(proxies))
+    elif order == "random":
+        random.shuffle(proxies)
+
+    if check:
+        proxies = [p for p in proxies if check_proxy(p)]
+
+    return proxies
+
+
+def select_proxy(proxies: List[str], order: str, index: int) -> str | None:
+    """Return proxy for ``index`` using ``order`` strategy."""
+    if not proxies:
+        return None
+    if order == "random":
+        return random.choice(proxies)
+    proxy_list = proxies if order == "asc" else list(reversed(proxies))
+    return proxy_list[index % len(proxy_list)]

--- a/smtpburst/send.py
+++ b/smtpburst/send.py
@@ -226,8 +226,12 @@ def bombing_mode(cfg: Config) -> None:
             throttle(cfg, cfg.SB_SGEMAILSPSEC)
             proxy = None
             if cfg.SB_PROXIES:
-                idx = (number + (b * cfg.SB_SGEMAILS) - 1) % len(cfg.SB_PROXIES)
-                proxy = cfg.SB_PROXIES[idx]
+                from . import proxy as proxy_util
+
+                idx = number + (b * cfg.SB_SGEMAILS) - 1
+                proxy = proxy_util.select_proxy(
+                    cfg.SB_PROXIES, cfg.SB_PROXY_ORDER, idx
+                )
             proc = Process(
                 target=sendmail,
                 args=(

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -222,3 +222,13 @@ def test_new_message_mode_flags():
     assert args.utf7_test
     assert args.header_tunnel_test
     assert args.control_char_test
+
+
+def test_proxy_order_cli():
+    args = burst_cli.parse_args(["--proxy-order", "random"], Config())
+    assert args.proxy_order == "random"
+
+
+def test_check_proxies_flag():
+    args = burst_cli.parse_args(["--check-proxies"], Config())
+    assert args.check_proxies

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,67 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from smtpburst import proxy
+
+
+def test_load_proxies_orders(tmp_path):
+    path = tmp_path / "p.txt"
+    path.write_text("a\nb\nc\n")
+    assert proxy.load_proxies(str(path)) == ["a", "b", "c"]
+    assert proxy.load_proxies(str(path), order="desc") == ["c", "b", "a"]
+    res = proxy.load_proxies(str(path), order="random")
+    assert sorted(res) == ["a", "b", "c"]
+
+
+def test_select_proxy_orders():
+    proxies = ["a", "b", "c"]
+    assert proxy.select_proxy(proxies, "asc", 3) == "a"
+    assert proxy.select_proxy(proxies, "desc", 1) == "b"
+    p = proxy.select_proxy(proxies, "random", 5)
+    assert p in proxies
+
+
+def test_check_proxy(monkeypatch):
+    calls = {}
+
+    def fake_ping(host):
+        calls["ping"] = host
+        return "pong"
+
+    def fake_dns(host):
+        calls["dns"] = host
+        return "1.2.3.4"
+
+    class DummySock:
+        def __init__(self, *a, **k):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def sendall(self, data):
+            calls["send"] = True
+
+        def recv(self, n):
+            return b"ok"
+
+    def fake_create(addr, timeout=5):
+        calls["conn"] = addr
+        return DummySock()
+
+    monkeypatch.setattr(proxy, "ping", fake_ping)
+    monkeypatch.setattr(proxy.socket, "gethostbyname", fake_dns)
+    monkeypatch.setattr(proxy.socket, "create_connection", fake_create)
+
+    assert proxy.check_proxy("h:1")
+    assert calls["ping"] == "h" and calls["dns"] == "h" and calls["conn"] == ("h", 1)
+
+
+def test_check_proxy_failure(monkeypatch):
+    monkeypatch.setattr(proxy, "ping", lambda h: "")
+    assert not proxy.check_proxy("bad:1")


### PR DESCRIPTION
## Summary
- add proxy order and checking options
- validate proxies when reading from file
- store new proxy settings in config
- support proxy selection order in send.bombing_mode
- document new flags in readme
- cover new features with tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c2125857c8325ad53291e239632f4