### PR TITLE
Remove path modifications from tests

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,7 +2,6 @@ import os
 import sys
 
 # Ensure project root is on sys.path for imports
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from smtpburst import __main__ as main_mod
 from smtpburst import send

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,6 @@ import pytest
 import logging
 
 # Ensure the project root is on sys.path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from smtpburst.send import sizeof_fmt, sendmail, throttle
 from smtpburst import send as burstGen


### PR DESCRIPTION
## Summary
- eliminate `sys.path` manipulations in `tests/test_main.py` and `tests/test_utils.py`
- rely on editable install for imports when running tests

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c216500c88325851154ce7af7e216