### PR TITLE
Improve alignment of ascii test report

### DIFF
--- a/smtpburst/report.py
+++ b/smtpburst/report.py
@@ -3,8 +3,11 @@ from typing import Dict, Any
 
 def ascii_report(results: Dict[str, Any]) -> str:
     """Return simple ASCII formatted report from ``results``."""
-    lines = ["+-----------------+", "| Test Report     |", "+-----------------+"]
+    width = max((len(name) for name in results), default=0)
+    border = "+" + "-" * (width + 2) + "+"
+    header = "| " + "Test Report".ljust(width) + " |"
+    lines = [border, header, border]
     for name, data in results.items():
-        lines.append(f"{name:20}: {data}")
-    lines.append("+-----------------+")
+        lines.append(f"{name:<{width}} : {data}")
+    lines.append(border)
     return "\n".join(lines)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from smtpburst.report import ascii_report
+
+
+def test_ascii_report_aligns_long_keys():
+    data = {
+        "short": 1,
+        "veryverylongkey": 2,
+        "mid": 3,
+    }
+    rep = ascii_report(data)
+    lines = [l for l in rep.splitlines() if ':' in l]
+    colon_positions = {line.index(':') for line in lines}
+    assert len(colon_positions) == 1
+    expected = len(max(data.keys(), key=len)) + 1
+    assert colon_positions.pop() == expected


### PR DESCRIPTION
## Summary
- adjust ascii report width to longest key
- use new width when formatting result lines
- test ascii report alignment with long keys

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c28891acc83259845225b7f5a4f59