### PR TITLE
Add outbound test email feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,7 @@ Additional CLI flags provide extended functionality:
 - `--ping-test HOST` run ping for HOST
 - `--traceroute-test HOST` run traceroute to HOST
 - `--rdns-test` verify reverse DNS for the configured server
+- `--outbound-test` send one test email and exit
 - `--silent` suppress all output
 - `--errors-only` show only error messages
 - `--warnings` show warnings and errors only
@@ -159,6 +160,12 @@ Silent mode suppresses all logs:
 
 ```bash
 $ python -m smtpburst --silent --server smtp.example.com
+```
+
+Send a quick outbound test email and exit:
+
+```bash
+$ python -m smtpburst --outbound-test --server smtp.example.com
 ```
 
 Run a DNS check and save the report:

--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -95,6 +95,11 @@ def main(argv=None):
         with open(args.enum_list, "r", encoding="utf-8") as fh:
             cfg.SB_ENUM_LIST = [line.strip() for line in fh if line.strip()]
 
+    if args.outbound_test:
+        logger.info("Sending outbound test message")
+        send.send_test_email(cfg)
+        return
+
     logger.info("Starting smtp-burst")
     send.bombing_mode(cfg)
 

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -260,6 +260,11 @@ def build_parser(cfg: Config) -> argparse.ArgumentParser:
         action="store_true",
         help="Verify reverse DNS for the configured server",
     )
+    parser.add_argument(
+        "--outbound-test",
+        action="store_true",
+        help="Send one test email and exit",
+    )
     level_group = parser.add_mutually_exclusive_group()
     level_group.add_argument(
         "--silent", action="store_true", help="Suppress all log output"

--- a/smtpburst/send.py
+++ b/smtpburst/send.py
@@ -203,6 +203,29 @@ def open_sockets(host: str, count: int, port: int = 25, cfg: Config | None = Non
     return attacks.open_sockets(host, count, port, delay, cfg)
 
 
+def send_test_email(cfg: Config) -> None:
+    """Send a single minimal email using ``sendmail`` helper."""
+
+    class Counter:
+        def __init__(self):
+            self.value = 0
+
+    msg = (
+        f"From: {cfg.SB_SENDER}\n"
+        f"To: {', '.join(cfg.SB_RECEIVERS)}\n"
+        f"Subject: {cfg.SB_SUBJECT}\n\n"
+        "smtp-burst outbound test\n"
+    ).encode("utf-8")
+
+    sendmail(
+        1,
+        1,
+        Counter(),
+        msg,
+        cfg,
+    )
+
+
 def bombing_mode(cfg: Config) -> None:
     """Run burst sending autonomously using provided configuration."""
     from multiprocessing import Manager, Process

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -179,6 +179,11 @@ def test_rdns_flag():
     assert args.rdns_test
 
 
+def test_outbound_test_flag():
+    args = burst_cli.parse_args(["--outbound-test"], Config())
+    assert args.outbound_test
+
+
 def test_template_and_enum_options(tmp_path):
     tpl = tmp_path / "tpl.txt"
     tpl.write_text("body")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -19,6 +19,23 @@ def test_main_open_sockets(monkeypatch):
     assert called["args"] == ("host.example", 2, 2525)
 
 
+def test_main_outbound_test(monkeypatch):
+    calls = []
+
+    def fake_send(cfg):
+        calls.append("test")
+
+    def fake_bomb(cfg):
+        calls.append("bomb")
+
+    monkeypatch.setattr(send, "send_test_email", fake_send)
+    monkeypatch.setattr(send, "bombing_mode", fake_bomb)
+
+    main_mod.main(["--outbound-test"])
+
+    assert calls == ["test"]
+
+
 def test_main_spawns_processes(monkeypatch):
     # Dummy Manager/Value implementation
     class DummyValue:


### PR DESCRIPTION
## Summary
- add `send_test_email` helper
- support `--outbound-test` CLI flag
- exit after sending a single outbound test message
- document feature with example
- test new CLI flag and main invocation

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c39141ad08325b04ea1b295fb77e9