### PR TITLE
Add SMTP AUTH login testing feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,7 @@ Additional CLI flags provide extended functionality:
 - `--vrfy-enum` enumerate users with VRFY
 - `--expn-enum` enumerate lists with EXPN
 - `--rcpt-enum` enumerate via RCPT TO
+- `--login-test` attempt SMTP AUTH logins using wordlists
 - `--ssl` connect using SMTPS
 - `--starttls` upgrade the connection with STARTTLS
 - `--check-dmarc DOMAIN` query DMARC record for DOMAIN

--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -100,6 +100,13 @@ def main(argv=None):
         send.send_test_email(cfg)
         return
 
+    if args.login_test:
+        logger.info("Running SMTP login test")
+        res = send.login_test(cfg)
+        if res:
+            logger.info(ascii_report(res))
+        return
+
     logger.info("Starting smtp-burst")
     send.bombing_mode(cfg)
 

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -197,6 +197,11 @@ def build_parser(cfg: Config) -> argparse.ArgumentParser:
     parser.add_argument("--expn-enum", action="store_true", help="Use EXPN to enumerate lists")
     parser.add_argument("--rcpt-enum", action="store_true", help="Use RCPT TO to enumerate users")
     parser.add_argument(
+        "--login-test",
+        action="store_true",
+        help="Attempt SMTP AUTH logins using wordlists",
+    )
+    parser.add_argument(
         "--ssl",
         action="store_true",
         default=cfg.SB_SSL,

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -184,6 +184,11 @@ def test_outbound_test_flag():
     assert args.outbound_test
 
 
+def test_login_test_flag():
+    args = burst_cli.parse_args(["--login-test"], Config())
+    assert args.login_test
+
+
 def test_template_and_enum_options(tmp_path):
     tpl = tmp_path / "tpl.txt"
     tpl.write_text("body")

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,0 +1,43 @@
+import logging
+from smtpburst import send
+from smtpburst.config import Config
+
+
+def test_login_test(monkeypatch, caplog):
+    class DummySMTP:
+        def __init__(self, host, port):
+            self.esmtp_features = {"auth": "LOGIN PLAIN"}
+            self.user = None
+            self.password = None
+
+        def starttls(self):
+            pass
+
+        def ehlo(self):
+            pass
+
+        def auth(self, mech, authobj, initial_response_ok=True):
+            if self.user == "u" and self.password == "p":
+                return (235, b"ok")
+            raise send.smtplib.SMTPAuthenticationError(535, b"bad")
+
+        def auth_login(self, challenge=None):
+            return self.user if challenge is None else self.password
+
+        def auth_plain(self, challenge=None):
+            return f"\0{self.user}\0{self.password}"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(send.smtplib, "SMTP", DummySMTP)
+    cfg = Config()
+    cfg.SB_USERLIST = ["u"]
+    cfg.SB_PASSLIST = ["p"]
+    with caplog.at_level(logging.INFO, logger="smtpburst.send"):
+        res = send.login_test(cfg)
+    assert res == {"LOGIN": True, "PLAIN": True}
+    assert any("Authentication LOGIN" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- implement `login_test` helper to try multiple SMTP AUTH methods
- add `--login-test` CLI option
- call the helper from the CLI entrypoint
- document the new flag
- test the new feature with mocked SMTP classes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c3dcad504832597938e57912557ff