### PR TITLE
Add reverse DNS verification utility

### DIFF
--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -180,7 +180,7 @@ def main(argv=None):
             results["rcpt"] = nettests.rcpt_enum(host, enum_items, port=port)
     if args.rdns_test:
         host, _ = send.parse_server(args.server)
-        from smtpburst.discovery import rdns
+        from smtpburst import rdns
 
         ok = rdns.verify(host)
         msg = "Reverse DNS: PASS" if ok else "Reverse DNS: FAIL"

--- a/smtpburst/rdns.py
+++ b/smtpburst/rdns.py
@@ -1,0 +1,16 @@
+"""Reverse DNS verification utilities."""
+
+from __future__ import annotations
+
+import socket
+
+
+def verify(host: str) -> bool:
+    """Return ``True`` if the PTR record for ``host`` resolves back to the same IP."""
+    try:
+        ip = socket.gethostbyname(host)
+        ptr, _, _ = socket.gethostbyaddr(ip)
+        forward_ip = socket.gethostbyname(ptr)
+        return forward_ip == ip
+    except Exception:  # pragma: no cover - network failures
+        return False

--- a/tests/test_rdns.py
+++ b/tests/test_rdns.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from smtpburst.discovery import rdns
+from smtpburst import rdns
 
 
 def test_verify_rdns_success(monkeypatch):


### PR DESCRIPTION
## Summary
- implement `smtpburst/rdns.py` for reverse DNS verification
- use new rdns module in CLI `--rdns-test` flag
- update rdns tests to import from new location

## Testing
- `pip install dnspython PyYAML`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c558b8ab483259a2bb264cb6756cd