### PR TITLE
Add performance testing utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,8 @@ Additional CLI flags provide extended functionality:
 - `--open-relay-test` test if the target SMTP server is an open relay
 - `--ping-test HOST` run ping for HOST
 - `--traceroute-test HOST` run traceroute to HOST
+- `--perf-test HOST` measure connection, SMTP and ping performance for HOST
+- `--baseline-host HOST` compare `--perf-test` results with HOST
 - `--rdns-test` verify reverse DNS for the configured server
 - `--outbound-test` send one test email and exit
 - `--silent` suppress all output
@@ -145,7 +147,8 @@ The following flags perform DNS and network checks using the utilities in
 - `--smtp-extensions`, `--cert-check`, `--port-scan`, `--probe-honeypot`,
   `--tls-discovery`, `--ssl-discovery`
 - `--blacklist-check`
-- `--open-relay-test`, `--ping-test`, `--traceroute-test`, `--rdns-test`
+- `--open-relay-test`, `--ping-test`, `--traceroute-test`, `--perf-test`,
+  `--baseline-host`, `--rdns-test`
 
 When these options are used, the report shown above is generated.
 

--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -7,6 +7,7 @@ from smtpburst import discovery
 from smtpburst.discovery import nettests
 from smtpburst.reporting import ascii_report
 from smtpburst import inbox
+from smtpburst import attacks
 
 logger = logging.getLogger(__name__)
 
@@ -169,6 +170,11 @@ def main(argv=None):
         results["ping"] = nettests.ping(args.ping_test)
     if args.traceroute_test:
         results["traceroute"] = nettests.traceroute(args.traceroute_test)
+    if args.perf_test:
+        host, port = send.parse_server(args.perf_test)
+        results["performance"] = attacks.performance_test(
+            host, port, baseline=args.baseline_host
+        )
     if args.vrfy_enum or args.expn_enum or args.rcpt_enum:
         host, port = send.parse_server(args.server)
         enum_items = cfg.SB_ENUM_LIST or cfg.SB_USERLIST

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -260,6 +260,8 @@ def build_parser(cfg: Config) -> argparse.ArgumentParser:
     )
     parser.add_argument("--ping-test", help="Host to ping")
     parser.add_argument("--traceroute-test", help="Host to traceroute")
+    parser.add_argument("--perf-test", help="Host to run performance test against")
+    parser.add_argument("--baseline-host", help="Baseline host for performance comparison")
     parser.add_argument(
         "--rdns-test",
         action="store_true",

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -109,6 +109,14 @@ def test_discovery_options():
     assert args.ping_test == "host"
 
 
+def test_perf_cli_options():
+    args = burst_cli.parse_args(
+        ["--perf-test", "host", "--baseline-host", "base"], Config()
+    )
+    assert args.perf_test == "host"
+    assert args.baseline_host == "base"
+
+
 def test_blacklist_option():
     args = burst_cli.parse_args(
         ["--blacklist-check", "1.2.3.4", "rbl.example"], Config()

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -1,0 +1,63 @@
+import smtpburst.attacks as attacks
+
+
+def _monkey_time(monkeypatch, *values):
+    it = iter(values)
+    monkeypatch.setattr(attacks.time, "monotonic", lambda: next(it))
+
+
+def test_connection_setup_time(monkeypatch):
+    class DummySock:
+        def close(self):
+            pass
+
+    monkeypatch.setattr(attacks.socket, "create_connection", lambda a: DummySock())
+    _monkey_time(monkeypatch, 0.0, 0.5)
+    assert attacks.connection_setup_time("h") == 0.5
+
+
+def test_smtp_handshake_time(monkeypatch):
+    class DummySMTP:
+        def __init__(self, *a, **k):
+            pass
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+        def starttls(self):
+            pass
+        def ehlo(self):
+            pass
+
+    monkeypatch.setattr(attacks.smtplib, "SMTP", DummySMTP)
+    monkeypatch.setattr(attacks.smtplib, "SMTP_SSL", DummySMTP)
+    _monkey_time(monkeypatch, 0.0, 0.4)
+    assert attacks.smtp_handshake_time("h") == 0.4
+
+
+def test_message_send_time(monkeypatch):
+    class DummySMTP:
+        def __init__(self, *a, **k):
+            pass
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+        def starttls(self):
+            pass
+        def sendmail(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(attacks.smtplib, "SMTP", DummySMTP)
+    monkeypatch.setattr(attacks.smtplib, "SMTP_SSL", DummySMTP)
+    _monkey_time(monkeypatch, 0.0, 0.7)
+    assert (
+        attacks.message_send_time("h", "s", ["r"], b"m")
+        == 0.7
+    )
+
+
+def test_ping_latency(monkeypatch):
+    monkeypatch.setattr(attacks.subprocess, "run", lambda *a, **k: None)
+    _monkey_time(monkeypatch, 0.0, 0.2)
+    assert attacks.ping_latency("h") == 0.2


### PR DESCRIPTION
## Summary
- extend attacks module with performance measurement helpers
- add CLI flags `--perf-test` and `--baseline-host`
- include performance results in the main report
- document new options
- test argument parsing and timing functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c5dc0b3288325a07826a915e1b3d3