### PR TITLE
Add SMTP AUTH test

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,9 @@ Additional CLI flags provide extended functionality:
 - `--expn-enum` enumerate lists with EXPN
 - `--rcpt-enum` enumerate via RCPT TO
 - `--login-test` attempt SMTP AUTH logins using wordlists
+- `--auth-test` test advertised SMTP AUTH mechanisms
+- `--username USER` username for `--auth-test`
+- `--password PASS` password for `--auth-test`
 - `--ssl` connect using SMTPS
 - `--starttls` upgrade the connection with STARTTLS
 - `--check-dmarc DOMAIN` query DMARC record for DOMAIN
@@ -96,6 +99,12 @@ Additional CLI flags provide extended functionality:
 - `--control-char-test` insert encoded control characters
 
 Run `smtp-burst --help` for the complete list of options.
+
+### Authentication Prerequisites
+
+The `--login-test` and `--auth-test` options require credentials. Supply
+wordlists with `--userlist` and `--passlist` or provide a single account using
+`--username` and `--password` for `--auth-test`.
 
 ## Report Format
 

--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -85,6 +85,10 @@ def main(argv=None):
     if args.passlist:
         with open(args.passlist, "r", encoding="utf-8") as fh:
             cfg.SB_PASSLIST = [line.strip() for line in fh if line.strip()]
+    if args.username:
+        cfg.SB_USERNAME = args.username
+    if args.password:
+        cfg.SB_PASSWORD = args.password
     if args.body_file:
         with open(args.body_file, "r", encoding="utf-8") as fh:
             cfg.SB_BODY = fh.read()
@@ -103,6 +107,16 @@ def main(argv=None):
     if args.login_test:
         logger.info("Running SMTP login test")
         res = send.login_test(cfg)
+        if res:
+            logger.info(ascii_report(res))
+        return
+
+    if args.auth_test:
+        logger.info("Running SMTP auth method test")
+        if not cfg.SB_USERNAME or not cfg.SB_PASSWORD:
+            logger.error("--auth-test requires --username and --password")
+            return
+        res = send.auth_test(cfg)
         if res:
             logger.info(ascii_report(res))
         return

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -202,6 +202,13 @@ def build_parser(cfg: Config) -> argparse.ArgumentParser:
         help="Attempt SMTP AUTH logins using wordlists",
     )
     parser.add_argument(
+        "--auth-test",
+        action="store_true",
+        help="Test advertised AUTH methods using --username/--password",
+    )
+    parser.add_argument("--username", help="Username for --auth-test")
+    parser.add_argument("--password", help="Password for --auth-test")
+    parser.add_argument(
         "--ssl",
         action="store_true",
         default=cfg.SB_SSL,

--- a/smtpburst/config.py
+++ b/smtpburst/config.py
@@ -33,6 +33,8 @@ class Config:
     SB_CHECK_PROXIES: bool = False
     SB_USERLIST: List[str] = field(default_factory=list)
     SB_PASSLIST: List[str] = field(default_factory=list)
+    SB_USERNAME: str = ""
+    SB_PASSWORD: str = ""
 
     # Security options
     SB_SSL: bool = False

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -189,6 +189,17 @@ def test_login_test_flag():
     assert args.login_test
 
 
+def test_auth_test_flag():
+    args = burst_cli.parse_args([
+        "--auth-test",
+        "--username",
+        "u",
+        "--password",
+        "p",
+    ], Config())
+    assert args.auth_test and args.username == "u" and args.password == "p"
+
+
 def test_template_and_enum_options(tmp_path):
     tpl = tmp_path / "tpl.txt"
     tpl.write_text("body")

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -41,3 +41,43 @@ def test_login_test(monkeypatch, caplog):
         res = send.login_test(cfg)
     assert res == {"LOGIN": True, "PLAIN": True}
     assert any("Authentication LOGIN" in r.getMessage() for r in caplog.records)
+
+
+def test_auth_test(monkeypatch, caplog):
+    class DummySMTP:
+        def __init__(self, host, port):
+            self.esmtp_features = {"auth": "LOGIN PLAIN"}
+            self.user = None
+            self.password = None
+
+        def starttls(self):
+            pass
+
+        def ehlo(self):
+            pass
+
+        def auth(self, mech, authobj, initial_response_ok=True):
+            if self.user == "u" and self.password == "p":
+                return (235, b"ok")
+            raise send.smtplib.SMTPAuthenticationError(535, b"bad")
+
+        def auth_login(self, challenge=None):
+            return self.user if challenge is None else self.password
+
+        def auth_plain(self, challenge=None):
+            return f"\0{self.user}\0{self.password}"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(send.smtplib, "SMTP", DummySMTP)
+    cfg = Config()
+    cfg.SB_USERNAME = "u"
+    cfg.SB_PASSWORD = "p"
+    with caplog.at_level(logging.INFO, logger="smtpburst.send"):
+        res = send.auth_test(cfg)
+    assert res == {"LOGIN": True, "PLAIN": True}
+    assert any("Authentication LOGIN" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- implement `auth_test` to check each advertised SMTP AUTH method
- add credentials fields in `Config` and CLI options to use them
- expose `--auth-test`, `--username`, `--password` flags
- call `auth_test` from the CLI and report using `ascii_report`
- document authentication prerequisites
- unit tests for new CLI options and `auth_test`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c5e6c5f18832589f756c3ccf1acd4