### PR TITLE
Add SMTP banner check

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,7 @@ Additional CLI flags provide extended functionality:
 - `--traceroute-test HOST` run traceroute to HOST
 - `--perf-test HOST` measure connection, SMTP and ping performance for HOST
 - `--baseline-host HOST` compare `--perf-test` results with HOST
+- `--banner-check` read the SMTP banner and verify reverse DNS
 - `--rdns-test` verify reverse DNS for the configured server
 - `--outbound-test` send one test email and exit
 - `--silent` suppress all output

--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -205,6 +205,11 @@ def main(argv=None):
         ok = rdns.verify(host)
         msg = "Reverse DNS: PASS" if ok else "Reverse DNS: FAIL"
         print(msg)
+    if args.banner_check:
+        banner, ok = discovery.banner_check(args.server)
+        print(f"Banner: {banner}")
+        msg = "Reverse DNS: PASS" if ok else "Reverse DNS: FAIL"
+        print(msg)
     if results:
         logger.info(ascii_report(results))
 

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -275,6 +275,11 @@ def build_parser(cfg: Config) -> argparse.ArgumentParser:
         help="Verify reverse DNS for the configured server",
     )
     parser.add_argument(
+        "--banner-check",
+        action="store_true",
+        help="Read SMTP banner and verify reverse DNS",
+    )
+    parser.add_argument(
         "--outbound-test",
         action="store_true",
         help="Send one test email and exit",

--- a/smtpburst/discovery/__init__.py
+++ b/smtpburst/discovery/__init__.py
@@ -10,6 +10,8 @@ from typing import Any, Dict, List
 import ssl
 import socket
 
+from .. import send, rdns
+
 
 def _lookup(domain: str, record: str) -> List[str]:
     """Return record strings for ``domain`` and ``record`` type."""
@@ -186,3 +188,14 @@ def probe_honeypot(host: str, port: int = 25) -> bool:
             return any(k in banner for k in keywords)
     except Exception:  # pragma: no cover - network issues
         return False
+
+
+def banner_check(server: str) -> tuple[str, bool]:
+    """Return banner string and reverse DNS status for ``server``."""
+    host, port = send.parse_server(server)
+    try:
+        with socket.create_connection((host, port), timeout=5) as s:
+            banner = s.recv(1024).decode(errors="ignore").strip()
+    except Exception:  # pragma: no cover - connection errors
+        return "", False
+    return banner, rdns.verify(host)

--- a/tests/test_banner.py
+++ b/tests/test_banner.py
@@ -1,0 +1,50 @@
+import os
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from smtpburst import discovery
+
+
+def test_banner_check_success(monkeypatch):
+    class DummyConn:
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+        def recv(self, n):
+            return b"220 test banner"
+
+    calls = {}
+
+    def fake_create(addr, timeout=5):
+        calls["addr"] = addr
+        return DummyConn()
+
+    monkeypatch.setattr(discovery.socket, "create_connection", fake_create)
+    monkeypatch.setattr(discovery.send, "parse_server", lambda s: ("host", 2525))
+    monkeypatch.setattr(discovery.rdns, "verify", lambda h: True)
+
+    banner, ok = discovery.banner_check("host:2525")
+    assert banner == "220 test banner"
+    assert ok
+    assert calls["addr"] == ("host", 2525)
+
+
+def test_banner_check_rdns_fail(monkeypatch):
+    class DummyConn:
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+        def recv(self, n):
+            return b"220 test"
+
+    monkeypatch.setattr(discovery.socket, "create_connection", lambda addr, timeout=5: DummyConn())
+    monkeypatch.setattr(discovery.send, "parse_server", lambda s: ("host", 25))
+    monkeypatch.setattr(discovery.rdns, "verify", lambda h: False)
+
+    banner, ok = discovery.banner_check("host")
+    assert banner == "220 test"
+    assert not ok

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -258,6 +258,11 @@ def test_proxy_order_cli():
     assert args.proxy_order == "random"
 
 
+def test_banner_check_flag():
+    args = burst_cli.parse_args(["--banner-check"], Config())
+    assert args.banner_check
+
+
 def test_check_proxies_flag():
     args = burst_cli.parse_args(["--check-proxies"], Config())
     assert args.check_proxies

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -126,3 +126,17 @@ def test_main_tls_discovery(monkeypatch):
 
     assert called['host'] == 'h'
     assert called['report'] == {'tls': {'TLSv1_2': {'supported': True}}}
+
+
+def test_main_banner_check(monkeypatch):
+    called = {}
+
+    def fake_banner_check(server):
+        called['server'] = server
+        return ('banner', True)
+
+    monkeypatch.setattr(main_mod.discovery, 'banner_check', fake_banner_check)
+
+    main_mod.main(['--banner-check', '--server', 'srv'])
+
+    assert called['server'] == 'srv'


### PR DESCRIPTION
## Summary
- implement `banner_check` utility
- expose `--banner-check` CLI flag
- support banner check in main entrypoint
- document new flag
- test banner checker and CLI integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c6a6778088325a327dcf67ef6fefe