### PR TITLE
Add platform-aware ping & traceroute

### DIFF
--- a/smtpburst/discovery/__init__.py
+++ b/smtpburst/discovery/__init__.py
@@ -6,6 +6,7 @@ from dns import resolver
 import ipaddress
 import smtplib
 import subprocess
+import platform
 from typing import Any, Dict, List
 import ssl
 import socket
@@ -56,13 +57,21 @@ def check_txt(domain: str) -> List[str]:
 def ping(host: str) -> str:
     """Return result of ``ping`` command for ``host``."""
     try:
-        proc = subprocess.run(
-            [
+        cmd = [
+            "ping",
+            "-c",
+            "1",
+            host,
+        ]
+        if platform.system().lower() == "windows":
+            cmd = [
                 "ping",
-                "-c",
+                "-n",
                 "1",
                 host,
-            ],
+            ]
+        proc = subprocess.run(
+            cmd,
             capture_output=True,
             text=True,
             check=False,
@@ -75,11 +84,17 @@ def ping(host: str) -> str:
 def traceroute(host: str) -> str:
     """Return result of ``traceroute`` command for ``host``."""
     try:
-        proc = subprocess.run(
-            [
-                "traceroute",
+        cmd = [
+            "traceroute",
+            host,
+        ]
+        if platform.system().lower() == "windows":
+            cmd = [
+                "tracert",
                 host,
-            ],
+            ]
+        proc = subprocess.run(
+            cmd,
             capture_output=True,
             text=True,
             check=False,

--- a/smtpburst/discovery/nettests.py
+++ b/smtpburst/discovery/nettests.py
@@ -6,14 +6,18 @@ from dns import resolver
 import ipaddress
 import smtplib
 import subprocess
+import platform
 from typing import Callable, Dict, List
 
 
 def ping(host: str) -> str:
     """Return output of ``ping`` command for ``host``."""
     try:
+        cmd = ["ping", "-c", "1", host]
+        if platform.system().lower() == "windows":
+            cmd = ["ping", "-n", "1", host]
         proc = subprocess.run(
-            ["ping", "-c", "1", host],
+            cmd,
             capture_output=True,
             text=True,
             check=False,
@@ -26,8 +30,11 @@ def ping(host: str) -> str:
 def traceroute(host: str) -> str:
     """Return output of ``traceroute`` command for ``host``."""
     try:
+        cmd = ["traceroute", host]
+        if platform.system().lower() == "windows":
+            cmd = ["tracert", host]
         proc = subprocess.run(
-            ["traceroute", host],
+            cmd,
             capture_output=True,
             text=True,
             check=False,

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -34,20 +34,42 @@ def test_check_spf(monkeypatch):
     assert discovery.check_spf("ex.com") == ["v=spf1 include:foo"]
 
 
-def test_ping(monkeypatch):
+def test_ping_posix(monkeypatch):
     def fake_run(cmd, capture_output, text, check):
-        assert cmd[-1] == "host"
+        assert cmd == ["ping", "-c", "1", "host"]
         return SimpleNamespace(stdout="pong")
 
+    monkeypatch.setattr(nettests.platform, "system", lambda: "Linux")
     monkeypatch.setattr(nettests.subprocess, "run", fake_run)
     assert nettests.ping("host") == "pong"
 
 
-def test_traceroute(monkeypatch):
+def test_ping_windows(monkeypatch):
     def fake_run(cmd, capture_output, text, check):
-        assert cmd[-1] == "host"
+        assert cmd == ["ping", "-n", "1", "host"]
+        return SimpleNamespace(stdout="pong")
+
+    monkeypatch.setattr(nettests.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(nettests.subprocess, "run", fake_run)
+    assert nettests.ping("host") == "pong"
+
+
+def test_traceroute_posix(monkeypatch):
+    def fake_run(cmd, capture_output, text, check):
+        assert cmd == ["traceroute", "host"]
         return SimpleNamespace(stdout="trace")
 
+    monkeypatch.setattr(nettests.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(nettests.subprocess, "run", fake_run)
+    assert nettests.traceroute("host") == "trace"
+
+
+def test_traceroute_windows(monkeypatch):
+    def fake_run(cmd, capture_output, text, check):
+        assert cmd == ["tracert", "host"]
+        return SimpleNamespace(stdout="trace")
+
+    monkeypatch.setattr(nettests.platform, "system", lambda: "Windows")
     monkeypatch.setattr(nettests.subprocess, "run", fake_run)
     assert nettests.traceroute("host") == "trace"
 


### PR DESCRIPTION
## Summary
- detect OS in discovery ping/traceroute helpers
- use Windows-compatible commands on Windows
- update discovery tests for OS detection

## Testing
- `pip install PyYAML dnspython`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68610b7634d48325848c4ed9474b5a5b