### PR TITLE
Add email attachment feature

### DIFF
--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -130,7 +130,7 @@ def main(argv=None):
         return
 
     logger.info("Starting smtp-burst")
-    send.bombing_mode(cfg)
+    send.bombing_mode(cfg, attachments=args.attach)
 
     results = {}
     if args.check_dmarc:

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -58,6 +58,12 @@ def build_parser(cfg: Config) -> argparse.ArgumentParser:
     )
     parser.add_argument("--body-file", help="File containing email body text")
     parser.add_argument(
+        "--attach",
+        nargs="+",
+        metavar="FILE",
+        help="Files to attach to each message",
+    )
+    parser.add_argument(
         "--emails-per-burst",
         type=int,
         default=cfg.SB_SGEMAILS,

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -84,6 +84,15 @@ def test_body_file_option(tmp_path):
     assert args.body_file == str(body_file)
 
 
+def test_attach_option(tmp_path):
+    f1 = tmp_path / "a.txt"
+    f2 = tmp_path / "b.txt"
+    f1.write_text("a")
+    f2.write_text("b")
+    args = burst_cli.parse_args(["--attach", str(f1), str(f2)], Config())
+    assert args.attach == [str(f1), str(f2)]
+
+
 def test_data_mode_option():
     args = burst_cli.parse_args(["--data-mode", "binary"], Config())
     assert args.data_mode == "binary"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -310,6 +310,24 @@ def test_append_message_control_chars():
     assert b"\x01\x02" in msg
 
 
+def test_append_message_with_attachment(tmp_path):
+    cfg = Config()
+    cfg.SB_SENDER = "a@b.com"
+    cfg.SB_RECEIVERS = ["c@d.com"]
+    cfg.SB_SUBJECT = "Sub"
+    cfg.SB_SIZE = 0
+    att = tmp_path / "f.txt"
+    att.write_text("hello")
+    msg_bytes = burstGen.appendMessage(cfg, [str(att)])
+    import email
+    m = email.message_from_bytes(msg_bytes)
+    assert m.is_multipart()
+    payload = m.get_payload()
+    assert len(payload) == 2
+    assert payload[1].get_filename() == "f.txt"
+    assert payload[1].get_payload(decode=True) == b"hello"
+
+
 def test_genData_length():
     for n in [0, 1, 10, 100]:
         assert len(datagen.generate(n, mode="ascii")) == n


### PR DESCRIPTION
## Summary
- support email attachments in appendMessage
- expose `--attach` CLI flag to send attachments
- update bombing mode to pass attachment paths
- test attachment parsing and email generation

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68611fee30708325851b7a0c830f71ce