### PR TITLE
Fix ascii_report width and add tests

### DIFF
--- a/smtpburst/reporting/__init__.py
+++ b/smtpburst/reporting/__init__.py
@@ -3,8 +3,13 @@ from typing import Dict, Any
 
 def ascii_report(results: Dict[str, Any]) -> str:
     """Return simple ASCII formatted report from ``results``."""
-    lines = ["+-----------------+", "| Test Report     |", "+-----------------+"]
+
+    width = max([len(k) for k in results] + [len("Test Report")])
+    border = "+" + "-" * (width + 2) + "+"
+    header = "| " + "Test Report" + " " * (width - len("Test Report")) + " |"
+
+    lines = [border, header, border]
     for name, data in results.items():
-        lines.append(f"{name:20}: {data}")
-    lines.append("+-----------------+")
+        lines.append(f"{name:<{width}}: {data}")
+    lines.append(border)
     return "\n".join(lines)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,18 @@
+import smtpburst.reporting as reporting
+
+
+def test_ascii_report_long_keys():
+    results = {"short": 1, "this_is_a_really_long_key": 2}
+    report = reporting.ascii_report(results)
+    lines = report.splitlines()
+
+    width = len("this_is_a_really_long_key")
+    border = "+" + "-" * (width + 2) + "+"
+    header = "| Test Report" + " " * (width - len("Test Report")) + " |"
+
+    assert lines[0] == border
+    assert lines[1] == header
+    assert lines[2] == border
+    assert lines[-1] == border
+    assert lines[3] == f"short{' ' * (width - len('short'))}: 1"
+    assert lines[4] == f"this_is_a_really_long_key: 2"


### PR DESCRIPTION
## Summary
- compute the width of the longest result key when formatting reports
- draw report borders based on the computed width
- test ascii report formatting with long keys

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68612ca43fc483258ecb7e680ad877b7