### PR TITLE
Add deterministic datagen tests

### DIFF
--- a/tests/test_datagen.py
+++ b/tests/test_datagen.py
@@ -1,0 +1,16 @@
+import secrets
+from smtpburst import datagen
+
+
+def test_generate_secure_binary_uses_token_bytes(monkeypatch):
+    monkeypatch.setattr(secrets, "token_bytes", lambda n: b"x" * n)
+    assert datagen.generate(4, mode="binary", secure=True) == b"x" * 4
+
+
+def test_generate_secure_ascii_uses_system_random(monkeypatch):
+    class DummyRandom:
+        def choice(self, seq):
+            return seq[0]
+
+    monkeypatch.setattr(secrets, "SystemRandom", lambda: DummyRandom())
+    assert datagen.generate(5, mode="ascii", secure=True) == b"a" * 5


### PR DESCRIPTION
## Summary
- add dedicated tests for `datagen` secure sources to ensure determinism

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68614a5a1a348325a0b833b5e22d53a2