### PR TITLE
Add login failure tests

### DIFF
--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -81,3 +81,83 @@ def test_auth_test(monkeypatch, caplog):
         res = send.auth_test(cfg)
     assert res == {"LOGIN": True, "PLAIN": True}
     assert any("Authentication LOGIN" in r.getMessage() for r in caplog.records)
+
+
+def test_login_test_fail(monkeypatch, caplog):
+    class DummySMTP:
+        def __init__(self, host, port):
+            self.esmtp_features = {"auth": "LOGIN PLAIN"}
+            self.user = None
+            self.password = None
+
+        def starttls(self):
+            pass
+
+        def ehlo(self):
+            pass
+
+        def auth(self, mech, authobj, initial_response_ok=True):
+            if self.user == "u" and self.password == "p":
+                return (235, b"ok")
+            raise send.smtplib.SMTPAuthenticationError(535, b"bad")
+
+        def auth_login(self, challenge=None):
+            return self.user if challenge is None else self.password
+
+        def auth_plain(self, challenge=None):
+            return f"\0{self.user}\0{self.password}"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(send.smtplib, "SMTP", DummySMTP)
+    cfg = Config()
+    cfg.SB_USERLIST = ["wrong"]
+    cfg.SB_PASSLIST = ["creds"]
+    with caplog.at_level(logging.INFO, logger="smtpburst.send"):
+        res = send.login_test(cfg)
+    assert res == {"LOGIN": False, "PLAIN": False}
+    assert any("Authentication LOGIN failed" in r.getMessage() for r in caplog.records)
+
+
+def test_auth_test_fail(monkeypatch, caplog):
+    class DummySMTP:
+        def __init__(self, host, port):
+            self.esmtp_features = {"auth": "LOGIN PLAIN"}
+            self.user = None
+            self.password = None
+
+        def starttls(self):
+            pass
+
+        def ehlo(self):
+            pass
+
+        def auth(self, mech, authobj, initial_response_ok=True):
+            if self.user == "u" and self.password == "p":
+                return (235, b"ok")
+            raise send.smtplib.SMTPAuthenticationError(535, b"bad")
+
+        def auth_login(self, challenge=None):
+            return self.user if challenge is None else self.password
+
+        def auth_plain(self, challenge=None):
+            return f"\0{self.user}\0{self.password}"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(send.smtplib, "SMTP", DummySMTP)
+    cfg = Config()
+    cfg.SB_USERNAME = "wrong"
+    cfg.SB_PASSWORD = "creds"
+    with caplog.at_level(logging.INFO, logger="smtpburst.send"):
+        res = send.auth_test(cfg)
+    assert res == {"LOGIN": False, "PLAIN": False}
+    assert any("Authentication LOGIN failed" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- test sending invalid login details
- expect failures in both login_test and auth_test
- check that log messages report the failed attempts

## Testing
- `pytest tests/test_login.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686158649dd48325a2f6b8a9a8481af2