### PR TITLE
Fix baseline parsing in performance_test

### DIFF
--- a/smtpburst/attacks/__init__.py
+++ b/smtpburst/attacks/__init__.py
@@ -6,6 +6,8 @@ import smtplib
 import subprocess
 from typing import List, Dict, Any
 
+from .. import send
+
 
 logger = logging.getLogger(__name__)
 
@@ -214,13 +216,6 @@ def performance_test(host: str, port: int = 25, baseline: str | None = None) -> 
 
     results = {"target": _measure(host, port)}
     if baseline:
-        if ":" in baseline:
-            b_host, b_port_str = baseline.rsplit(":", 1)
-            try:
-                b_port = int(b_port_str)
-            except ValueError:
-                b_port = 25
-        else:
-            b_host, b_port = baseline, 25
+        b_host, b_port = send.parse_server(baseline)
         results["baseline"] = _measure(b_host, b_port)
     return results


### PR DESCRIPTION
## Summary
- simplify baseline handling in `performance_test`
- import `send` module to parse server strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861b1dae04083259e6ade84ca14c6c7