### PR TITLE
Add DataMode enum

### DIFF
--- a/smtpburst/datagen.py
+++ b/smtpburst/datagen.py
@@ -1,7 +1,18 @@
 import random
 import secrets
 import string
-from typing import List, Optional, TextIO
+from enum import Enum
+from typing import List, Optional, TextIO, Union
+
+
+class DataMode(Enum):
+    """Available data generation modes."""
+
+    ASCII = "ascii"
+    BINARY = "binary"
+    UTF8 = "utf8"
+    DICT = "dict"
+    REPEAT = "repeat"
 
 
 def gen_ascii(size: int, secure: bool = False) -> str:
@@ -68,7 +79,7 @@ def compile_wordlist(path: str) -> List[str]:
 
 def generate(
     size: int,
-    mode: str = "ascii",
+    mode: Union[DataMode, str] = DataMode.ASCII,
     *,
     secure: bool = False,
     words: Optional[List[str]] = None,
@@ -76,13 +87,19 @@ def generate(
     stream: Optional[TextIO] = None,
 ) -> bytes:
     """Generate ``size`` bytes of data using ``mode``."""
-    if mode == "binary":
+    if isinstance(mode, str):
+        try:
+            mode = DataMode(mode.lower())
+        except ValueError:
+            mode = DataMode.ASCII
+
+    if mode is DataMode.BINARY:
         return gen_binary(size, secure=secure, stream=stream)
-    if mode == "utf8":
+    if mode is DataMode.UTF8:
         return gen_utf8(size, secure=secure).encode("utf-8")
-    if mode == "dict":
+    if mode is DataMode.DICT:
         return gen_dictionary(size, words or []).encode("utf-8")
-    if mode == "repeat":
+    if mode is DataMode.REPEAT:
         return gen_repeat(repeat or "", size).encode("utf-8")
 
     # default ascii

--- a/smtpburst/send.py
+++ b/smtpburst/send.py
@@ -61,7 +61,7 @@ def appendMessage(cfg: Config, attachments: Optional[List[str]] = None) -> bytes
     )
     rand = datagen.generate(
         cfg.SB_SIZE,
-        mode=cfg.SB_DATA_MODE,
+        mode=datagen.DataMode(cfg.SB_DATA_MODE),
         secure=cfg.SB_SECURE_RANDOM,
         words=cfg.SB_DICT_WORDS,
         repeat=cfg.SB_REPEAT_STRING,

--- a/tests/test_datagen.py
+++ b/tests/test_datagen.py
@@ -4,7 +4,9 @@ from smtpburst import datagen
 
 def test_generate_secure_binary_uses_token_bytes(monkeypatch):
     monkeypatch.setattr(secrets, "token_bytes", lambda n: b"x" * n)
-    assert datagen.generate(4, mode="binary", secure=True) == b"x" * 4
+    assert (
+        datagen.generate(4, mode=datagen.DataMode.BINARY, secure=True) == b"x" * 4
+    )
 
 
 def test_generate_secure_ascii_uses_system_random(monkeypatch):
@@ -13,4 +15,6 @@ def test_generate_secure_ascii_uses_system_random(monkeypatch):
             return seq[0]
 
     monkeypatch.setattr(secrets, "SystemRandom", lambda: DummyRandom())
-    assert datagen.generate(5, mode="ascii", secure=True) == b"a" * 5
+    assert (
+        datagen.generate(5, mode=datagen.DataMode.ASCII, secure=True) == b"a" * 5
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -330,7 +330,7 @@ def test_append_message_with_attachment(tmp_path):
 
 def test_genData_length():
     for n in [0, 1, 10, 100]:
-        assert len(datagen.generate(n, mode="ascii")) == n
+        assert len(datagen.generate(n, mode=datagen.DataMode.ASCII)) == n
 
 
 def test_throttle_combines_delay(monkeypatch):


### PR DESCRIPTION
## Summary
- introduce `DataMode` enum for payload generation
- update `generate` to handle enum values or strings
- convert usage in `send` and tests to the new enum

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e02f33ec832598943fa7999bba7e