### PR TITLE
Add helper function for applying CLI args

### DIFF
--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -49,30 +49,7 @@ def main(argv=None):
         )
         return
 
-    cfg.SB_SERVER = args.server
-    cfg.SB_SENDER = args.sender
-    cfg.SB_RECEIVERS = args.receivers
-    cfg.SB_SUBJECT = args.subject
-    cfg.SB_SGEMAILS = args.emails_per_burst
-    cfg.SB_BURSTS = args.bursts
-    cfg.SB_SGEMAILSPSEC = args.email_delay
-    cfg.SB_BURSTSPSEC = args.burst_delay
-    cfg.SB_GLOBAL_DELAY = args.global_delay
-    cfg.SB_OPEN_SOCKETS_DELAY = args.socket_delay
-    cfg.SB_TARPIT_THRESHOLD = args.tarpit_threshold
-    cfg.SB_SIZE = args.size
-    cfg.SB_DATA_MODE = args.data_mode
-    cfg.SB_REPEAT_STRING = args.repeat_string
-    cfg.SB_PER_BURST_DATA = args.per_burst_data
-    cfg.SB_SECURE_RANDOM = args.secure_random
-    cfg.SB_TEST_UNICODE = args.unicode_case_test
-    cfg.SB_TEST_UTF7 = args.utf7_test
-    cfg.SB_TEST_TUNNEL = args.header_tunnel_test
-    cfg.SB_TEST_CONTROL = args.control_char_test
-    cfg.SB_STOPFAIL = args.stop_on_fail
-    cfg.SB_STOPFQNT = args.stop_fail_count
-    cfg.SB_SSL = args.ssl
-    cfg.SB_STARTTLS = args.starttls
+    cli.apply_args_to_config(cfg, args)
 
     if args.dict_file:
         cfg.SB_DICT_WORDS = send.datagen.compile_wordlist(Path(args.dict_file))

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -394,3 +394,42 @@ def parse_args(args=None, cfg: Config | None = None) -> argparse.Namespace:
             )
         parser.set_defaults(**config_data)
     return parser.parse_args(args)
+
+
+def apply_args_to_config(cfg: Config, args: argparse.Namespace) -> None:
+    """Map argument values onto Config attributes."""
+
+    MAP = {
+        "server": "SB_SERVER",
+        "sender": "SB_SENDER",
+        "receivers": "SB_RECEIVERS",
+        "subject": "SB_SUBJECT",
+        "emails_per_burst": "SB_SGEMAILS",
+        "bursts": "SB_BURSTS",
+        "email_delay": "SB_SGEMAILSPSEC",
+        "burst_delay": "SB_BURSTSPSEC",
+        "global_delay": "SB_GLOBAL_DELAY",
+        "socket_delay": "SB_OPEN_SOCKETS_DELAY",
+        "tarpit_threshold": "SB_TARPIT_THRESHOLD",
+        "size": "SB_SIZE",
+        "data_mode": "SB_DATA_MODE",
+        "repeat_string": "SB_REPEAT_STRING",
+        "per_burst_data": "SB_PER_BURST_DATA",
+        "secure_random": "SB_SECURE_RANDOM",
+        "unicode_case_test": "SB_TEST_UNICODE",
+        "utf7_test": "SB_TEST_UTF7",
+        "header_tunnel_test": "SB_TEST_TUNNEL",
+        "control_char_test": "SB_TEST_CONTROL",
+        "stop_on_fail": "SB_STOPFAIL",
+        "stop_fail_count": "SB_STOPFQNT",
+        "ssl": "SB_SSL",
+        "starttls": "SB_STARTTLS",
+        "proxy_order": "SB_PROXY_ORDER",
+        "check_proxies": "SB_CHECK_PROXIES",
+    }
+
+    for arg_name, cfg_attr in MAP.items():
+        value = getattr(args, arg_name, None)
+        if value is not None:
+            setattr(cfg, cfg_attr, value)
+


### PR DESCRIPTION
## Summary
- add `apply_args_to_config()` to reduce duplicated assignments
- call the helper from `main`

## Testing
- `pip install -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686859a711408325885e8a6235131eb9