### PR TITLE
Rename appendMessage and refactor message creation

### DIFF
--- a/smtpburst/send.py
+++ b/smtpburst/send.py
@@ -28,11 +28,11 @@ def throttle(cfg: Config, delay: float = 0.0) -> None:
         time.sleep(total)
 
 
-def appendMessage(cfg: Config, attachments: Optional[List[str]] = None) -> bytes:
+def append_message(cfg: Config, attachments: Optional[List[str]] = None) -> bytes:
     """Construct the message using config values and append random data.
 
-    If ``attachments`` are provided, build a multipart message using the
-    :mod:`email` package and include each file as an attachment.
+    Message creation always uses :class:`email.message.EmailMessage`.  When
+    ``attachments`` are provided they are included as additional parts.
     """
     receivers = ", ".join(cfg.SB_RECEIVERS)
     body = cfg.SB_BODY
@@ -44,21 +44,7 @@ def appendMessage(cfg: Config, attachments: Optional[List[str]] = None) -> bytes
             receiver=receivers,
             subject=cfg.SB_SUBJECT,
         )
-    if cfg.SB_TEST_UNICODE:
-        from_hdr = f"FrOm: {cfg.SB_SENDER}"
-        to_hdr = f"tO: {receivers}"
-    else:
-        from_hdr = f"From: {cfg.SB_SENDER}"
-        to_hdr = f"To: {receivers}"
-    subject_hdr = f"Subject: {cfg.SB_SUBJECT}"
-    if cfg.SB_TEST_TUNNEL:
-        subject_hdr += "\nX-Orig: overlap"
-    base = (
-        f"{from_hdr}\n"
-        f"{to_hdr}\n"
-        f"{subject_hdr}\n\n"
-        f"{body}\n\n"
-    )
+
     rand = datagen.generate(
         cfg.SB_SIZE,
         mode=datagen.DataMode(cfg.SB_DATA_MODE),
@@ -68,10 +54,7 @@ def appendMessage(cfg: Config, attachments: Optional[List[str]] = None) -> bytes
         stream=cfg.SB_RAND_STREAM,
     )
     encoding = "utf-7" if cfg.SB_TEST_UTF7 else "utf-8"
-    payload = base.encode(encoding) + rand
-
-    if not attachments:
-        return payload
+    payload = body.encode(encoding) + b"\n\n" + rand
 
     msg = EmailMessage()
     if cfg.SB_TEST_UNICODE:
@@ -86,19 +69,20 @@ def appendMessage(cfg: Config, attachments: Optional[List[str]] = None) -> bytes
 
     msg.set_content(payload, maintype="text", subtype="plain", cte="8bit")
 
-    for path in attachments:
-        data = Path(path).read_bytes()
-        ctype, _ = mimetypes.guess_type(path)
-        if ctype:
-            maintype, subtype = ctype.split("/", 1)
-        else:
-            maintype, subtype = "application", "octet-stream"
-        msg.add_attachment(
-            data,
-            maintype=maintype,
-            subtype=subtype,
-            filename=Path(path).name,
-        )
+    if attachments:
+        for path in attachments:
+            data = Path(path).read_bytes()
+            ctype, _ = mimetypes.guess_type(path)
+            if ctype:
+                maintype, subtype = ctype.split("/", 1)
+            else:
+                maintype, subtype = "application", "octet-stream"
+            msg.add_attachment(
+                data,
+                maintype=maintype,
+                subtype=subtype,
+                filename=Path(path).name,
+            )
 
     return msg.as_bytes()
 
@@ -402,12 +386,12 @@ def bombing_mode(cfg: Config, attachments: Optional[List[str]] = None) -> None:
     logger.info("Generating %s of data to append to message", sizeof_fmt(cfg.SB_SIZE))
     manager = Manager()
     fail_count = manager.Value("i", 0)
-    message = appendMessage(cfg, attachments)
+    message = append_message(cfg, attachments)
     logger.info("Message using %s of random data", sizeof_fmt(sys.getsizeof(message)))
 
     for b in range(cfg.SB_BURSTS):
         if cfg.SB_PER_BURST_DATA:
-            message = appendMessage(cfg, attachments)
+            message = append_message(cfg, attachments)
         numbers = range(1, cfg.SB_SGEMAILS + 1)
         procs = []
         if fail_count.value >= cfg.SB_STOPFQNT and cfg.SB_STOPFAIL:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -93,7 +93,7 @@ def test_main_spawns_processes(monkeypatch):
     monkeypatch.setattr("multiprocessing.Process", DummyProcess)
 
     monkeypatch.setattr(send, "time", type("T", (), {"sleep": lambda *a, **k: None}))
-    monkeypatch.setattr(send, "appendMessage", lambda cfg, attachments=None: b"msg")
+    monkeypatch.setattr(send, "append_message", lambda cfg, attachments=None: b"msg")
     monkeypatch.setattr(send, "sizeof_fmt", lambda n: str(n))
 
     main_mod.main(["--emails-per-burst", "2", "--bursts", "3"])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -249,7 +249,7 @@ def test_append_message_uses_subject_and_body(monkeypatch):
     cfg.SB_SUBJECT = "Sub"
     cfg.SB_BODY = "Body"
     cfg.SB_SIZE = 0
-    msg = burstGen.appendMessage(cfg)
+    msg = burstGen.append_message(cfg)
     assert b"Subject: Sub" in msg
     assert b"Body" in msg
 
@@ -261,7 +261,7 @@ def test_append_message_template():
     cfg.SB_SUBJECT = "Sub"
     cfg.SB_TEMPLATE = "Hello {receiver} from {sender}"
     cfg.SB_SIZE = 0
-    msg = burstGen.appendMessage(cfg)
+    msg = burstGen.append_message(cfg)
     assert b"Hello c@d.com" in msg
 
 
@@ -272,7 +272,7 @@ def test_append_message_unicode_headers():
     cfg.SB_SUBJECT = "Sub"
     cfg.SB_SIZE = 0
     cfg.SB_TEST_UNICODE = True
-    msg = burstGen.appendMessage(cfg)
+    msg = burstGen.append_message(cfg)
     assert b"FrOm:" in msg and b"tO:" in msg
 
 
@@ -284,7 +284,7 @@ def test_append_message_utf7_body():
     cfg.SB_BODY = "\u2713"  # checkmark
     cfg.SB_SIZE = 0
     cfg.SB_TEST_UTF7 = True
-    msg = burstGen.appendMessage(cfg)
+    msg = burstGen.append_message(cfg)
     assert b"+JxM" in msg
 
 
@@ -295,7 +295,7 @@ def test_append_message_tunnel_header():
     cfg.SB_SUBJECT = "Sub"
     cfg.SB_SIZE = 0
     cfg.SB_TEST_TUNNEL = True
-    msg = burstGen.appendMessage(cfg)
+    msg = burstGen.append_message(cfg)
     assert b"X-Orig: overlap" in msg
 
 
@@ -306,7 +306,7 @@ def test_append_message_control_chars():
     cfg.SB_SUBJECT = "Sub"
     cfg.SB_SIZE = 0
     cfg.SB_TEST_CONTROL = True
-    msg = burstGen.appendMessage(cfg)
+    msg = burstGen.append_message(cfg)
     assert b"\x01\x02" in msg
 
 
@@ -318,7 +318,7 @@ def test_append_message_with_attachment(tmp_path):
     cfg.SB_SIZE = 0
     att = tmp_path / "f.txt"
     att.write_text("hello")
-    msg_bytes = burstGen.appendMessage(cfg, [str(att)])
+    msg_bytes = burstGen.append_message(cfg, [str(att)])
     import email
     m = email.message_from_bytes(msg_bytes)
     assert m.is_multipart()


### PR DESCRIPTION
## Summary
- rename `appendMessage` to `append_message`
- always use `EmailMessage` API when creating outbound messages
- update calls and tests for the new function name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68685c4ad1748325a7813978d144edcb