### PR TITLE
Fix ping return code handling

### DIFF
--- a/smtpburst/discovery/nettests.py
+++ b/smtpburst/discovery/nettests.py
@@ -22,7 +22,9 @@ def ping(host: str) -> str:
             text=True,
             check=False,
         )
-        return proc.stdout.strip()
+        if proc.returncode == 0:
+            return proc.stdout.strip()
+        return ""
     except Exception as exc:  # pragma: no cover - ping may not exist
         return str(exc)
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -37,7 +37,7 @@ def test_check_spf(monkeypatch):
 def test_ping_posix(monkeypatch):
     def fake_run(cmd, capture_output, text, check):
         assert cmd == ["ping", "-c", "1", "host"]
-        return SimpleNamespace(stdout="pong")
+        return SimpleNamespace(stdout="pong", returncode=0)
 
     monkeypatch.setattr(nettests.platform, "system", lambda: "Linux")
     monkeypatch.setattr(nettests.subprocess, "run", fake_run)
@@ -47,11 +47,21 @@ def test_ping_posix(monkeypatch):
 def test_ping_windows(monkeypatch):
     def fake_run(cmd, capture_output, text, check):
         assert cmd == ["ping", "-n", "1", "host"]
-        return SimpleNamespace(stdout="pong")
+        return SimpleNamespace(stdout="pong", returncode=0)
 
     monkeypatch.setattr(nettests.platform, "system", lambda: "Windows")
     monkeypatch.setattr(nettests.subprocess, "run", fake_run)
     assert nettests.ping("host") == "pong"
+
+
+def test_ping_failure(monkeypatch):
+    def fake_run(cmd, capture_output, text, check):
+        assert cmd == ["ping", "-c", "1", "host"]
+        return SimpleNamespace(stdout="error", returncode=1)
+
+    monkeypatch.setattr(nettests.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(nettests.subprocess, "run", fake_run)
+    assert nettests.ping("host") == ""
 
 
 def test_traceroute_posix(monkeypatch):


### PR DESCRIPTION
## Summary
- ensure `ping` only returns stdout on success
- adjust discovery tests for new `ping` behavior
- add a failing ping test

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868f00e02488325b085f4bec7b04e3b