### PR TITLE
Improve pipeline error handling for missing PyYAML

### DIFF
--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -32,7 +32,11 @@ def main(argv=None):
     if args.pipeline_file:
         from . import pipeline
 
-        runner = pipeline.load_pipeline(args.pipeline_file)
+        try:
+            runner = pipeline.load_pipeline(args.pipeline_file)
+        except SystemExit as exc:
+            print(exc)
+            return
         runner.run()
         return
 

--- a/smtpburst/pipeline.py
+++ b/smtpburst/pipeline.py
@@ -86,7 +86,7 @@ class PipelineRunner:
 def load_pipeline(path: str) -> PipelineRunner:
     """Load pipeline YAML file and return a :class:`PipelineRunner`."""
     if yaml is None:
-        raise RuntimeError("PyYAML not installed")
+        raise SystemExit("Pipeline feature requires PyYAML")
     with open(path, "r", encoding="utf-8") as fh:
         data = yaml.safe_load(fh) or {}
     if not isinstance(data, dict) or "steps" not in data:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -15,6 +15,12 @@ def test_cli_pipeline_option():
     assert args.pipeline_file == "p.yml"
 
 
+def test_load_pipeline_missing_yaml(monkeypatch):
+    monkeypatch.setattr(pipeline, "yaml", None)
+    with pytest.raises(SystemExit, match="PyYAML"):
+        pipeline.load_pipeline("p.yml")
+
+
 @pytest.mark.skipif(pipeline.yaml is None, reason="PyYAML not installed")
 def test_pipeline_runner_stop(monkeypatch, tmp_path):
     calls = []


### PR DESCRIPTION
## Summary
- raise `SystemExit` in `pipeline.load_pipeline` when PyYAML is missing
- catch that `SystemExit` in `__main__` and print a user-friendly message
- test that the new error occurs when PyYAML is absent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868f019f1008325a983dbbb35c4bc6d