### PR TITLE
Support IPv6 server strings

### DIFF
--- a/smtpburst/send.py
+++ b/smtpburst/send.py
@@ -208,7 +208,23 @@ def sendmail(
 
 def parse_server(server: str) -> Tuple[str, int]:
     """Return ``(host, port)`` parsed from ``server`` string."""
-    if ":" in server:
+    if server.startswith("["):
+        end = server.find("]")
+        if end != -1:
+            host = server[1:end]
+            rest = server[end + 1 :]
+        else:
+            host = server[1:]
+            rest = ""
+        if rest.startswith(":"):
+            port_str = rest[1:]
+            try:
+                port = int(port_str)
+            except ValueError:
+                port = 25
+        else:
+            port = 25
+    elif ":" in server:
         host, port_str = server.rsplit(":", 1)
         try:
             port = int(port_str)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -56,6 +56,18 @@ def test_parse_server_bad_port():
     assert port == 25
 
 
+def test_parse_server_ipv6_with_port():
+    host, port = burstGen.parse_server("[2001:db8::1]:587")
+    assert host == "2001:db8::1"
+    assert port == 587
+
+
+def test_parse_server_ipv6_default_port():
+    host, port = burstGen.parse_server("[2001:db8::1]")
+    assert host == "2001:db8::1"
+    assert port == 25
+
+
 def test_open_sockets_creates_connections(monkeypatch):
     connections = []
 


### PR DESCRIPTION
## Summary
- handle IPv6 literal host strings like `[2001:db8::1]:587`
- add tests for IPv6 host parsing

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686a7358ddc88325a619b198c5c52292