### PR TITLE
Fix flake8 E501

### DIFF
--- a/smtpburst/attacks/__init__.py
+++ b/smtpburst/attacks/__init__.py
@@ -160,7 +160,12 @@ def connection_setup_time(host: str, port: int = 25) -> float:
     return end - start
 
 
-def smtp_handshake_time(host: str, port: int = 25, use_ssl: bool = False, start_tls: bool = False) -> float:
+def smtp_handshake_time(
+    host: str,
+    port: int = 25,
+    use_ssl: bool = False,
+    start_tls: bool = False,
+) -> float:
     """Return time to complete SMTP handshake with ``host``."""
     smtp_cls = smtplib.SMTP_SSL if use_ssl else smtplib.SMTP
     start = time.monotonic()
@@ -193,11 +198,20 @@ def message_send_time(
 def ping_latency(host: str) -> float:
     """Return latency of a single ICMP ping to ``host``."""
     start = time.monotonic()
-    subprocess.run(["ping", "-c", "1", host], capture_output=True, text=True, check=False)
+    subprocess.run(
+        ["ping", "-c", "1", host],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
     return time.monotonic() - start
 
 
-def performance_test(host: str, port: int = 25, baseline: str | None = None) -> Dict[str, Any]:
+def performance_test(
+    host: str,
+    port: int = 25,
+    baseline: str | None = None,
+) -> Dict[str, Any]:
     """Run latency tests against ``host`` and optionally ``baseline``."""
 
     def _measure(target: str, p: int) -> Dict[str, float]:

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -29,14 +29,28 @@ CLI_OPTIONS: Iterable[CLIOption] = [
     }),
     (("--subject",), {"default_attr": "SB_SUBJECT", "help": "Email subject line"}),
     (("--body-file",), {"help": "File containing email body text"}),
-    (("--attach",), {"nargs": "+", "metavar": "FILE", "help": "Files to attach to each message"}),
+    (
+        ("--attach",),
+        {
+            "nargs": "+",
+            "metavar": "FILE",
+            "help": "Files to attach to each message",
+        },
+    ),
 
     (("--emails-per-burst",), {
         "type": int,
         "default_attr": "SB_SGEMAILS",
         "help": "Number of emails per burst",
     }),
-    (("--bursts",), {"type": int, "default_attr": "SB_BURSTS", "help": "Number of bursts to send"}),
+    (
+        ("--bursts",),
+        {
+            "type": int,
+            "default_attr": "SB_BURSTS",
+            "help": "Number of bursts to send",
+        },
+    ),
     (("--email-delay",), {
         "type": float,
         "default_attr": "SB_SGEMAILSPSEC",
@@ -68,9 +82,28 @@ CLI_OPTIONS: Iterable[CLIOption] = [
         "default": 0,
         "help": "Open N TCP sockets and hold them open instead of sending email",
     }),
-    (("--socket-duration",), {"type": float, "help": "Close open sockets after SECONDS"}),
-    (("--socket-iterations",), {"type": int, "help": "Run the socket loop this many times before closing"}),
-    (("--port",), {"type": int, "default": 25, "help": "TCP port to use for socket mode"}),
+    (
+        ("--socket-duration",),
+        {
+            "type": float,
+            "help": "Close open sockets after SECONDS",
+        },
+    ),
+    (
+        ("--socket-iterations",),
+        {
+            "type": int,
+            "help": "Run the socket loop this many times before closing",
+        },
+    ),
+    (
+        ("--port",),
+        {
+            "type": int,
+            "default": 25,
+            "help": "TCP port to use for socket mode",
+        },
+    ),
 
     (("--size",), {
         "type": int,
@@ -83,7 +116,13 @@ CLI_OPTIONS: Iterable[CLIOption] = [
         "help": "Payload generation mode",
     }),
     (("--dict-file",), {"help": "Word list for dictionary mode"}),
-    (("--repeat-string",), {"default_attr": "SB_REPEAT_STRING", "help": "String to repeat for repeat mode"}),
+    (
+        ("--repeat-string",),
+        {
+            "default_attr": "SB_REPEAT_STRING",
+            "help": "String to repeat for repeat mode",
+        },
+    ),
     (("--per-burst-data",), {
         "action": "store_true",
         "default_attr": "SB_PER_BURST_DATA",
@@ -144,11 +183,29 @@ CLI_OPTIONS: Iterable[CLIOption] = [
     (("--passlist",), {"help": "Password wordlist for SMTP AUTH"}),
     (("--template-file",), {"help": "Phishing template file"}),
     (("--enum-list",), {"help": "Wordlist for enumeration"}),
-    (("--vrfy-enum",), {"action": "store_true", "help": "Use VRFY to enumerate users"}),
-    (("--expn-enum",), {"action": "store_true", "help": "Use EXPN to enumerate lists"}),
-    (("--rcpt-enum",), {"action": "store_true", "help": "Use RCPT TO to enumerate users"}),
-    (("--login-test",), {"action": "store_true", "help": "Attempt SMTP AUTH logins using wordlists"}),
-    (("--auth-test",), {"action": "store_true", "help": "Test advertised AUTH methods using --username/--password"}),
+    (
+        ("--vrfy-enum",),
+        {"action": "store_true", "help": "Use VRFY to enumerate users"},
+    ),
+    (
+        ("--expn-enum",),
+        {"action": "store_true", "help": "Use EXPN to enumerate lists"},
+    ),
+    (
+        ("--rcpt-enum",),
+        {"action": "store_true", "help": "Use RCPT TO to enumerate users"},
+    ),
+    (
+        ("--login-test",),
+        {"action": "store_true", "help": "Attempt SMTP AUTH logins using wordlists"},
+    ),
+    (
+        ("--auth-test",),
+        {
+            "action": "store_true",
+            "help": "Test advertised AUTH methods using --username/--password",
+        },
+    ),
     (("--username",), {"help": "Username for --auth-test"}),
     (("--password",), {"help": "Password for --auth-test"}),
 
@@ -172,11 +229,26 @@ CLI_OPTIONS: Iterable[CLIOption] = [
     (("--lookup-mx",), {"help": "Domain to query MX records for"}),
     (("--smtp-extensions",), {"help": "Host to discover SMTP extensions"}),
     (("--cert-check",), {"help": "Host to retrieve TLS certificate from"}),
-    (("--port-scan",), {"nargs": "+", "help": "Host followed by one or more ports to scan"}),
-    (("--probe-honeypot",), {"help": "Host to probe for SMTP honeypot"}),
-    (("--tls-discovery",), {"help": "Host to probe TLS versions and certificate validity"}),
-    (("--ssl-discovery",), {"help": "Host to discover supported legacy SSL versions"}),
-    (("--blacklist-check",), {"nargs": "+", "help": "IP followed by one or more DNSBL zones to query"}),
+    (
+        ("--port-scan",),
+        {"nargs": "+", "help": "Host followed by one or more ports to scan"},
+    ),
+    (
+        ("--probe-honeypot",),
+        {"help": "Host to probe for SMTP honeypot"},
+    ),
+    (
+        ("--tls-discovery",),
+        {"help": "Host to probe TLS versions and certificate validity"},
+    ),
+    (
+        ("--ssl-discovery",),
+        {"help": "Host to discover supported legacy SSL versions"},
+    ),
+    (
+        ("--blacklist-check",),
+        {"nargs": "+", "help": "IP followed by one or more DNSBL zones to query"},
+    ),
     (("--imap-check",), {
         "nargs": 4,
         "metavar": ("HOST", "USER", "PASS", "CRITERIA"),
@@ -187,18 +259,61 @@ CLI_OPTIONS: Iterable[CLIOption] = [
         "metavar": ("HOST", "USER", "PASS", "PATTERN"),
         "help": "Check POP3 inbox for messages containing PATTERN",
     }),
-    (("--open-relay-test",), {"action": "store_true", "help": "Test if the target SMTP server is an open relay"}),
-    (("--ping-test",), {"help": "Host to ping"}),
-    (("--traceroute-test",), {"help": "Host to traceroute"}),
-    (("--perf-test",), {"help": "Host to run performance test against"}),
-    (("--baseline-host",), {"help": "Baseline host for performance comparison"}),
-    (("--rdns-test",), {"action": "store_true", "help": "Verify reverse DNS for the configured server"}),
-    (("--banner-check",), {"action": "store_true", "help": "Read SMTP banner and verify reverse DNS"}),
-    (("--outbound-test",), {"action": "store_true", "help": "Send one test email and exit"}),
+    (
+        ("--open-relay-test",),
+        {
+            "action": "store_true",
+            "help": "Test if the target SMTP server is an open relay",
+        },
+    ),
+    (
+        ("--ping-test",),
+        {"help": "Host to ping"},
+    ),
+    (
+        ("--traceroute-test",),
+        {"help": "Host to traceroute"},
+    ),
+    (
+        ("--perf-test",),
+        {"help": "Host to run performance test against"},
+    ),
+    (
+        ("--baseline-host",),
+        {"help": "Baseline host for performance comparison"},
+    ),
+    (
+        ("--rdns-test",),
+        {
+            "action": "store_true",
+            "help": "Verify reverse DNS for the configured server",
+        },
+    ),
+    (
+        ("--banner-check",),
+        {"action": "store_true", "help": "Read SMTP banner and verify reverse DNS"},
+    ),
+    (
+        ("--outbound-test",),
+        {"action": "store_true", "help": "Send one test email and exit"},
+    ),
 
-    (("--silent",), {"action": "store_true", "group": "log", "help": "Suppress all log output"}),
-    (("--errors-only",), {"action": "store_true", "group": "log", "help": "Show only error messages"}),
-    (("--warnings",), {"action": "store_true", "group": "log", "help": "Show warnings and errors only"}),
+    (
+        ("--silent",),
+        {"action": "store_true", "group": "log", "help": "Suppress all log output"},
+    ),
+    (
+        ("--errors-only",),
+        {"action": "store_true", "group": "log", "help": "Show only error messages"},
+    ),
+    (
+        ("--warnings",),
+        {
+            "action": "store_true",
+            "group": "log",
+            "help": "Show warnings and errors only",
+        },
+    ),
 ]
 
 

--- a/smtpburst/pipeline.py
+++ b/smtpburst/pipeline.py
@@ -52,7 +52,12 @@ class PipelineError(Exception):
 class PipelineRunner:
     """Execute pipeline steps sequentially."""
 
-    def __init__(self, steps: List[Dict[str, Any]], stop_on_fail: bool = False, fail_threshold: int = 1):
+    def __init__(
+        self,
+        steps: List[Dict[str, Any]],
+        stop_on_fail: bool = False,
+        fail_threshold: int = 1,
+    ):
         self.steps = steps
         self.stop_on_fail = stop_on_fail
         self.fail_threshold = fail_threshold
@@ -96,4 +101,8 @@ def load_pipeline(path: str) -> PipelineRunner:
         raise PipelineError("'steps' must be a list")
     stop_on_fail = bool(data.get("stop_on_fail", False))
     fail_threshold = int(data.get("fail_threshold", 1))
-    return PipelineRunner(steps, stop_on_fail=stop_on_fail, fail_threshold=fail_threshold)
+    return PipelineRunner(
+        steps,
+        stop_on_fail=stop_on_fail,
+        fail_threshold=fail_threshold,
+    )

--- a/smtpburst/send.py
+++ b/smtpburst/send.py
@@ -283,7 +283,11 @@ def _attempt_auth(
         return False
 
 
-def _smtp_authenticate(cfg: Config, users: List[str], passwords: List[str]) -> dict[str, bool]:
+def _smtp_authenticate(
+    cfg: Config,
+    users: List[str],
+    passwords: List[str],
+) -> dict[str, bool]:
     """Try authentication attempts for ``users``/``passwords`` and return results."""
 
     host, port = parse_server(cfg.SB_SERVER)

--- a/smtpburst/tlstest.py
+++ b/smtpburst/tlstest.py
@@ -15,11 +15,20 @@ VERSIONS = {
 }
 
 
-def test_versions(host: str, port: int = 443, timeout: float = 3.0) -> Dict[str, Dict[str, Any]]:
+def test_versions(
+    host: str,
+    port: int = 443,
+    timeout: float = 3.0,
+) -> Dict[str, Dict[str, Any]]:
     """Attempt TLS connections for each version and return details."""
     results: Dict[str, Dict[str, Any]] = {}
     for name, ver in VERSIONS.items():
-        info: Dict[str, Any] = {"supported": False, "valid": None, "protocol": None, "certificate": None}
+        info: Dict[str, Any] = {
+            "supported": False,
+            "valid": None,
+            "protocol": None,
+            "certificate": None,
+        }
 
         # First try with certificate verification enabled
         ctx = ssl.create_default_context()
@@ -44,7 +53,10 @@ def test_versions(host: str, port: int = 443, timeout: float = 3.0) -> Dict[str,
                 nctx.maximum_version = ver
                 with socket.create_connection((host, port), timeout=timeout) as raw:
                     with nctx.wrap_socket(raw, server_hostname=host) as sock:
-                        info.update(protocol=sock.version(), certificate=sock.getpeercert())
+                        info.update(
+                            protocol=sock.version(),
+                            certificate=sock.getpeercert(),
+                        )
             except Exception:
                 pass
         except Exception:

--- a/tests/test_banner.py
+++ b/tests/test_banner.py
@@ -41,7 +41,11 @@ def test_banner_check_rdns_fail(monkeypatch):
         def recv(self, n):
             return b"220 test"
 
-    monkeypatch.setattr(discovery.socket, "create_connection", lambda addr, timeout=5: DummyConn())
+    monkeypatch.setattr(
+        discovery.socket,
+        "create_connection",
+        lambda addr, timeout=5: DummyConn(),
+    )
     monkeypatch.setattr(discovery.send, "parse_server", lambda s: ("host", 25))
     monkeypatch.setattr(discovery.rdns, "verify", lambda h: False)
 

--- a/tests/test_tlstest.py
+++ b/tests/test_tlstest.py
@@ -18,7 +18,9 @@ except ImportError:
 
 def _generate_cert(tmp_path):
     key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, u"localhost")])
+    subject = issuer = x509.Name(
+        [x509.NameAttribute(NameOID.COMMON_NAME, u"localhost")]
+    )
     cert = (
         x509.CertificateBuilder()
         .subject_name(subject)
@@ -60,7 +62,11 @@ def _start_server(certfile, keyfile):
                 conn, _ = sock.accept()
             except socket.timeout:
                 continue
-            with ctx.wrap_socket(conn, server_side=True, do_handshake_on_connect=False) as s:
+            with ctx.wrap_socket(
+                conn,
+                server_side=True,
+                do_handshake_on_connect=False,
+            ) as s:
                 try:
                     s.do_handshake()
                     s.recv(1)


### PR DESCRIPTION
## Summary
- wrap long function signatures and argument lists
- expand long CLI option definitions
- reformat ping subprocess call
- break long lines in pipeline and TLS tests

## Testing
- `flake8 --select E501`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dns')*

------
https://chatgpt.com/codex/tasks/task_e_686a811d36288325ae28ebbc447da2d6