### PR TITLE
Add __all__ list for discovery helpers

### DIFF
--- a/smtpburst/discovery/__init__.py
+++ b/smtpburst/discovery/__init__.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-"""DNS and network discovery utilities."""
+"""DNS and network discovery utilities.
+
+This module exposes ``ping``, ``traceroute``, ``check_rbl`` and
+``test_open_relay`` from :mod:`smtpburst.discovery.nettests` for convenience.
+"""
 
 from dns import resolver
 import smtplib
@@ -16,6 +20,13 @@ from .nettests import (
 )
 
 from .. import send, rdns
+
+__all__ = [
+    "ping",
+    "traceroute",
+    "check_rbl",
+    "test_open_relay",
+]
 
 
 def _lookup(domain: str, record: str) -> List[str]:


### PR DESCRIPTION
## Summary
- expose ping, traceroute, check_rbl and test_open_relay via `__all__`
- mention these helpers in the discovery package docstring

## Testing
- `pip install -q dnspython PyYAML`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686da351c77c83259d59e16667809b5f