### PR TITLE
Add --version option

### DIFF
--- a/smtpburst/__init__.py
+++ b/smtpburst/__init__.py
@@ -1,5 +1,8 @@
 """smtp-burst library package."""
 
+# Package version
+__version__ = "0.1.0"
+
 from . import (
     send,
     config,

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -4,6 +4,7 @@ import warnings
 from typing import Any, Dict, Iterable, Tuple
 
 from .config import Config
+from . import __version__
 
 try:
     import yaml
@@ -18,6 +19,7 @@ CLIOption = Tuple[Tuple[str, ...], Dict[str, Any]]
 # for the default value.  A ``group`` key specifies the mutually exclusive
 # logging group.
 CLI_OPTIONS: Iterable[CLIOption] = [
+    (("--version",), {"action": "version", "version": __version__, "help": "Show program version and exit"}),
     (("--config",), {"help": "Path to JSON/YAML config file"}),
     (("--pipeline-file",), {"help": "YAML file describing discovery/attack pipeline"}),
     (("--server",), {"default_attr": "SB_SERVER", "help": "SMTP server to connect to"}),

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -7,6 +7,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from smtpburst import cli as burst_cli
 from smtpburst.config import Config
+from smtpburst import __version__
 
 import logging
 from smtpburst import __main__ as main_mod
@@ -327,3 +328,10 @@ def test_parse_args_missing_config(tmp_path):
     cfg_path = tmp_path / "missing.json"
     with pytest.raises(SystemExit):
         burst_cli.parse_args(["--config", str(cfg_path)], Config())
+
+
+def test_version_option(capsys):
+    with pytest.raises(SystemExit):
+        burst_cli.parse_args(["--version"], Config())
+    out = capsys.readouterr().out
+    assert out.strip() == __version__


### PR DESCRIPTION
## Summary
- expose package version in `smtpburst.__init__`
- add a `--version` CLI option using argparse's built-in version action
- test that the version flag exits and prints the package version

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686da35dfba08325a0260733cc3c5d87