### PR TITLE
Implement IPv6 nibble reversal for DNSBL lookups

### DIFF
--- a/smtpburst/discovery/nettests.py
+++ b/smtpburst/discovery/nettests.py
@@ -71,7 +71,7 @@ def blacklist_check(ip: str, zones: List[str]) -> Dict[str, str]:
     if ip_obj.version == 4:
         reversed_ip = ".".join(reversed(ip.split(".")))
     else:  # pragma: no cover - IPv6 rarely used in tests
-        reversed_ip = ".".join(reversed(ip_obj.exploded.split(":")))
+        reversed_ip = ".".join(reversed(ip_obj.exploded.replace(":", "")))
 
     for zone in zones:
         qname = f"{reversed_ip}.{zone}"

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -99,6 +99,23 @@ def test_check_rbl(monkeypatch):
     assert calls == ["4.3.2.1.listed.example", "4.3.2.1.clean.example"]
 
 
+def test_check_rbl_ipv6(monkeypatch):
+    calls = []
+
+    def fake_resolve(domain, record):
+        calls.append(domain)
+        raise discovery.resolver.NXDOMAIN
+
+    monkeypatch.setattr(nettests.resolver, "resolve", fake_resolve)
+    res = nettests.blacklist_check("2001:db8::1", ["zone.example"])
+    expected = (
+        "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2"
+        ".zone.example"
+    )
+    assert res == {"zone.example": "not listed"}
+    assert calls == [expected]
+
+
 def test_open_relay_test(monkeypatch):
     class DummySMTP:
         def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## Summary
- nibble-reverse IPv6 addresses when generating DNSBL lookup names
- add a new unit test covering IPv6 blacklist checks

## Testing
- `pytest -q`
- `flake8` *(fails: `./smtpburst/cli.py:21:89: E501 line too long (109 > 88 characters)`)*

------
https://chatgpt.com/codex/tasks/task_e_686da8ff8d0483259c2346ee416a6af6