### PR TITLE
Validate negative size in generate

### DIFF
--- a/smtpburst/datagen.py
+++ b/smtpburst/datagen.py
@@ -87,6 +87,8 @@ def generate(
     stream: Optional[TextIO] = None,
 ) -> bytes:
     """Generate ``size`` bytes of data using ``mode``."""
+    if size < 0:
+        raise ValueError("size must be non-negative")
     if isinstance(mode, str):
         try:
             mode = DataMode(mode.lower())

--- a/tests/test_datagen.py
+++ b/tests/test_datagen.py
@@ -1,4 +1,5 @@
 import secrets
+import pytest
 from smtpburst import datagen
 
 
@@ -18,3 +19,8 @@ def test_generate_secure_ascii_uses_system_random(monkeypatch):
     assert (
         datagen.generate(5, mode=datagen.DataMode.ASCII, secure=True) == b"a" * 5
     )
+
+
+def test_generate_negative_size():
+    with pytest.raises(ValueError):
+        datagen.generate(-1)


### PR DESCRIPTION
## Summary
- raise an error in `datagen.generate()` when `size` is negative
- test `generate` error handling for negative size

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ed184357483259ce59c0a4c36c6c8