### PR TITLE
Fix flake8 violations

### DIFF
--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -18,7 +18,14 @@ CLIOption = Tuple[Tuple[str, ...], Dict[str, Any]]
 # for the default value.  A ``group`` key specifies the mutually exclusive
 # logging group.
 CLI_OPTIONS: Iterable[CLIOption] = [
-    (("--version",), {"action": "version", "version": __version__, "help": "Show program version and exit"}),
+    (
+        ("--version",),
+        {
+            "action": "version",
+            "version": __version__,
+            "help": "Show program version and exit",
+        },
+    ),
     (("--config",), {"help": "Path to JSON/YAML config file"}),
     (("--pipeline-file",), {"help": "YAML file describing discovery/attack pipeline"}),
     (("--server",), {"default_attr": "SB_SERVER", "help": "SMTP server to connect to"}),
@@ -375,7 +382,6 @@ def parse_args(args=None, cfg: Config | None = None) -> argparse.Namespace:
             )
         parser.set_defaults(**config_data)
     return parser.parse_args(args)
-
 
 
 def apply_args_to_config(cfg: Config, args: argparse.Namespace) -> None:

--- a/smtpburst/send.py
+++ b/smtpburst/send.py
@@ -1,5 +1,4 @@
 import smtplib
-import socket
 import time
 import sys
 import logging
@@ -141,7 +140,11 @@ def sendmail(
                             "Non-blocking socket (timeout=0) is not supported"
                         )
                     if self.debuglevel > 0:
-                        self._print_debug("connect: to", (host, port), self.source_address)
+                        self._print_debug(
+                            "connect: to",
+                            (host, port),
+                            self.source_address,
+                        )
                     sock = socks.socksocket()
                     sock.set_proxy(socks.SOCKS5, ph, pp)
                     if timeout is not None:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -188,8 +188,16 @@ def test_check_certificate(monkeypatch):
         def wrap_socket(self, sock, server_hostname=None):
             return DummySock()
 
-    monkeypatch.setattr(discovery.ssl, "create_default_context", lambda: DummyCtx())
-    monkeypatch.setattr(discovery.socket, "create_connection", lambda addr, timeout=3: DummyRaw())
+    monkeypatch.setattr(
+        discovery.ssl,
+        "create_default_context",
+        lambda: DummyCtx(),
+    )
+    monkeypatch.setattr(
+        discovery.socket,
+        "create_connection",
+        lambda addr, timeout=3: DummyRaw(),
+    )
 
     res = discovery.check_certificate("h")
     assert res["subject"] == "s"


### PR DESCRIPTION
## Summary
- split long lines in `smtpburst/send.py`
- tidy CLI option formatting and spacing
- wrap long monkeypatch statements in discovery tests
- remove unused `socket` import
- keep flake8 happy

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_686ed17f20d4832590f63b723f27a707