### PR TITLE
Handle pipeline errors

### DIFF
--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -34,7 +34,7 @@ def main(argv=None):
 
         try:
             runner = pipeline.load_pipeline(args.pipeline_file)
-        except SystemExit as exc:
+        except (SystemExit, pipeline.PipelineError) as exc:
             print(exc)
             return
         runner.run()

--- a/smtpburst/send.py
+++ b/smtpburst/send.py
@@ -1,4 +1,5 @@
 import smtplib
+import socket
 import time
 import sys
 import logging

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,7 @@
 
 from smtpburst import __main__ as main_mod
 from smtpburst import send
+from smtpburst import pipeline
 import logging
 
 
@@ -162,3 +163,15 @@ def test_main_banner_check(monkeypatch):
     main_mod.main(['--banner-check', '--server', 'srv'])
 
     assert called['server'] == 'srv'
+
+
+def test_main_pipeline_error(monkeypatch, capsys):
+    def fake_load(path):
+        raise pipeline.PipelineError("bad pipeline")
+
+    monkeypatch.setattr(pipeline, "load_pipeline", fake_load)
+
+    main_mod.main(["--pipeline-file", "p.yml"])
+
+    out = capsys.readouterr().out
+    assert "bad pipeline" in out


### PR DESCRIPTION
## Summary
- catch PipelineError in `smtpburst.__main__`
- test pipeline error path via the CLI
- restore `socket` import for `send` to keep tests working

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ee7dba8c88325822cfc361e7ee564