### PR TITLE
Document TLS certificate retrieval

### DIFF
--- a/smtpburst/discovery/__init__.py
+++ b/smtpburst/discovery/__init__.py
@@ -96,7 +96,11 @@ def smtp_extensions(host: str, port: int = 25) -> List[str]:
 
 
 def check_certificate(host: str, port: int = 443) -> Dict[str, Any]:
-    """Return TLS certificate details for ``host``."""
+    """Return TLS certificate details for ``host``.
+
+    A secure connection is established using :func:`ssl.create_default_context`
+    and the peer certificate is retrieved with :meth:`ssl.SSLSocket.getpeercert`.
+    """
     try:
         ctx = ssl.create_default_context()
         with socket.create_connection((host, port), timeout=3) as raw:


### PR DESCRIPTION
## Summary
- document that `check_certificate` connects with `create_default_context` and retrieves the peer certificate via `getpeercert`

## Testing
- `pytest tests/test_discovery.py::test_check_certificate -q`
- `pytest tests/test_discovery.py tests/test_tls_probe.py tests/test_ssl_probe.py tests/test_tlstest.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686ef0039c5c832592dcafca8970dca8