### PR TITLE
Add configurable delay to smurf_test

### DIFF
--- a/smtpburst/attacks/__init__.py
+++ b/smtpburst/attacks/__init__.py
@@ -6,6 +6,8 @@ import smtplib
 import subprocess
 from typing import List, Dict, Any
 
+from ..config import Config
+
 from .. import send
 
 
@@ -114,10 +116,10 @@ def tcp_reset_flood(host: str, port: int, count: int):
     logger.info("Performed %s TCP resets on %s:%s", count, host, port)
 
 
-def smurf_test(target: str, count: int):
+def smurf_test(target: str, count: int, delay: float = Config.SB_SMURF_DELAY) -> None:
     """Simulate a smurf attack by issuing ping requests."""
     for _ in range(count):
-        time.sleep(0.01)
+        time.sleep(delay)
     logger.info("Simulated smurf attack against %s %s times", target, count)
 
 

--- a/tests/test_attacks.py
+++ b/tests/test_attacks.py
@@ -22,3 +22,13 @@ def test_performance_test(monkeypatch):
     }
 
     assert res == {"target": expected, "baseline": expected}
+
+
+def test_smurf_test_delay(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(attacks.time, "sleep", lambda d: calls.append(d))
+
+    attacks.smurf_test("t", 3, delay=0.05)
+
+    assert calls == [0.05, 0.05, 0.05]


### PR DESCRIPTION
## Summary
- allow passing a delay to `smurf_test` instead of using a fixed sleep
- add unit test verifying the delay parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eeff82508832589c004e45a5b9f1c