### PR TITLE
Add timeout handling for open_sockets

### DIFF
--- a/smtpburst/attacks/__init__.py
+++ b/smtpburst/attacks/__init__.py
@@ -21,17 +21,19 @@ def open_sockets(
     *,
     duration: float | None = None,
     iterations: int | None = None,
+    timeout: float = 10.0,
 ) -> None:
     """Open ``count`` TCP sockets to ``host`` and keep them open.
 
     ``duration`` limits how long sockets remain open in seconds.
     ``iterations`` limits how many delay loops run before closing.
+    ``timeout`` is passed to :func:`socket.create_connection`.
     ``KeyboardInterrupt`` still exits immediately.
     """
     sockets: List[socket.socket] = []
     for _ in range(count):
         try:
-            s = socket.create_connection((host, port))
+            s = socket.create_connection((host, port), timeout=timeout)
         except Exception as exc:  # pragma: no cover - logging path tested separately
             logger.warning("Failed to open socket to %s:%s: %s", host, port, exc)
             continue

--- a/smtpburst/send.py
+++ b/smtpburst/send.py
@@ -270,6 +270,7 @@ def open_sockets(
 ) -> None:
     """Delegate to :mod:`smtpburst.attacks` implementation."""
     delay = cfg.SB_OPEN_SOCKETS_DELAY if cfg else 1.0
+    timeout = cfg.SB_TIMEOUT if cfg else 10.0
     return attacks.open_sockets(
         host,
         count,
@@ -278,6 +279,7 @@ def open_sockets(
         cfg,
         duration=duration,
         iterations=iterations,
+        timeout=timeout,
     )
 
 


### PR DESCRIPTION
## Summary
- add a `timeout` parameter to `attacks.open_sockets` and pass it to `socket.create_connection`
- forward `cfg.SB_TIMEOUT` in `send.open_sockets`
- update utilities tests for new behavior
- add new unit tests for timeout propagation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ef00d64388325866a058136898873