### PR TITLE
Expose nettests utilities via discovery package

### DIFF
--- a/smtpburst/discovery/__init__.py
+++ b/smtpburst/discovery/__init__.py
@@ -14,6 +14,13 @@ from typing import Any, Dict, List
 
 # Import discovery tests individually when used to avoid unused imports
 
+from .nettests import (
+    ping,
+    traceroute,
+    blacklist_check as check_rbl,
+    open_relay_test as test_open_relay,
+)
+
 from .. import send, rdns
 
 __all__ = [


### PR DESCRIPTION
## Summary
- export `ping`, `traceroute`, `check_rbl` and `test_open_relay` from `nettests`
- keep helper list in `__all__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eeffcba308325a121df6fbc7e3f6f