### PR TITLE
Refactor proxy connection in sendmail

### DIFF
--- a/smtpburst/send.py
+++ b/smtpburst/send.py
@@ -1,5 +1,4 @@
 import smtplib
-import socket
 import time
 import sys
 import logging
@@ -146,13 +145,14 @@ def sendmail(
                             (host, port),
                             self.source_address,
                         )
-                    sock = socks.socksocket()
-                    sock.set_proxy(socks.SOCKS5, ph, pp)
-                    if timeout is not None:
-                        sock.settimeout(timeout)
-                    if self.source_address:
-                        sock.bind(self.source_address)
-                    sock.connect((host, port))
+                    sock = socks.create_connection(
+                        (host, port),
+                        timeout=timeout,
+                        proxy_type=socks.SOCKS5,
+                        proxy_addr=ph,
+                        proxy_port=pp,
+                        source_address=self.source_address,
+                    )
                     if smtp_cls is smtplib.SMTP_SSL:
                         sock = self.context.wrap_socket(
                             sock, server_hostname=self._host


### PR DESCRIPTION
## Summary
- use `socks.create_connection` inside `sendmail`
- update proxy socket tests to match new approach

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ef160f1c483259feb5d7be07a5d1c