### PR TITLE
Validate pipeline step mapping entries

### DIFF
--- a/smtpburst/pipeline.py
+++ b/smtpburst/pipeline.py
@@ -66,6 +66,8 @@ class PipelineRunner:
 
     def run(self) -> List[Any]:
         for step in self.steps:
+            if not isinstance(step, dict):
+                raise PipelineError("Step must be a mapping")
             action = step.get("action")
             if not action:
                 raise PipelineError("Step missing action")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -119,3 +119,16 @@ def test_pipeline_runner_stop_threshold(monkeypatch, tmp_path):
     res = runner.run()
     assert calls == ["bad", "bad"]
     assert len(res) == 2
+
+
+@pytest.mark.skipif(pipeline.yaml is None, reason="PyYAML not installed")
+def test_pipeline_step_not_mapping(tmp_path):
+    import yaml
+
+    cfg = {"steps": ["oops"]}
+    path = tmp_path / "p.yaml"
+    path.write_text(yaml.safe_dump(cfg))
+
+    runner = pipeline.load_pipeline(str(path))
+    with pytest.raises(pipeline.PipelineError, match="mapping"):
+        runner.run()


### PR DESCRIPTION
## Summary
- ensure `PipelineRunner` verifies each pipeline step is a mapping
- test invalid pipeline with non-mapping step

## Testing
- `pytest -k pipeline -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870037654e88325a73150024b9ee3bc