### PR TITLE
Fix ruff import warnings

### DIFF
--- a/smtpburst/discovery/__init__.py
+++ b/smtpburst/discovery/__init__.py
@@ -1,10 +1,10 @@
-from __future__ import annotations
-
 """DNS and network discovery utilities.
 
 This module exposes ``ping``, ``traceroute``, ``check_rbl`` and
 ``test_open_relay`` from :mod:`smtpburst.discovery.nettests` for convenience.
 """
+
+from __future__ import annotations
 
 from dns import resolver
 import smtplib

--- a/smtpburst/discovery/nettests.py
+++ b/smtpburst/discovery/nettests.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Network test utilities such as ping, traceroute and open relay checks."""
+
+from __future__ import annotations
 
 from dns import resolver
 import ipaddress

--- a/smtpburst/discovery/ssl_probe.py
+++ b/smtpburst/discovery/ssl_probe.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Legacy SSL version discovery utilities."""
+
+from __future__ import annotations
 
 from typing import Dict
 import socket

--- a/smtpburst/discovery/tls_probe.py
+++ b/smtpburst/discovery/tls_probe.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """TLS version discovery utilities."""
+
+from __future__ import annotations
 
 from typing import Dict
 import socket

--- a/smtpburst/pipeline.py
+++ b/smtpburst/pipeline.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Simple pipeline runner for smtp-burst discovery and attack actions."""
+
+from __future__ import annotations
 
 from typing import Any, Dict, List, Callable
 import logging

--- a/smtpburst/proxy.py
+++ b/smtpburst/proxy.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Utilities for handling SOCKS proxies."""
+
+from __future__ import annotations
 
 import random
 import socket

--- a/smtpburst/send.py
+++ b/smtpburst/send.py
@@ -1,5 +1,5 @@
 import smtplib
-import socket
+import socket  # noqa: F401 - used by tests for monkeypatching
 import time
 import sys
 import logging

--- a/smtpburst/tlstest.py
+++ b/smtpburst/tlstest.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """TLS connection testing utilities."""
+
+from __future__ import annotations
 
 from typing import Dict, Any
 import socket


### PR DESCRIPTION
## Summary
- move docstrings before `from __future__` imports
- put all imports after docstrings/`__future__`
- keep `socket` imported for tests

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871869dd4f883258f4cad91f68ac615