### PR TITLE
Add IPv6 detection to parse_server

### DIFF
--- a/smtpburst/send.py
+++ b/smtpburst/send.py
@@ -248,11 +248,15 @@ def parse_server(server: str) -> Tuple[str, int]:
         else:
             port = 25
     elif ":" in server:
-        host, port_str = server.rsplit(":", 1)
-        try:
-            port = int(port_str)
-        except ValueError:
+        if server.count(":") > 1 and not server.startswith("["):
+            host = server
             port = 25
+        else:
+            host, port_str = server.rsplit(":", 1)
+            try:
+                port = int(port_str)
+            except ValueError:
+                port = 25
     else:
         host = server
         port = 25

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -66,6 +66,12 @@ def test_parse_server_ipv6_default_port():
     assert port == 25
 
 
+def test_parse_server_bare_ipv6():
+    host, port = burstGen.parse_server("2001:db8::1")
+    assert host == "2001:db8::1"
+    assert port == 25
+
+
 def test_open_sockets_creates_connections(monkeypatch):
     connections = []
 


### PR DESCRIPTION
## Summary
- correctly parse bare IPv6 server strings in `parse_server`
- verify with new unit test

## Testing
- `python -m pytest -q`
- `ruff check smtpburst/send.py tests/test_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68743369281083259c77933c0fa7e647