### PR TITLE
Add optional deps for tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -192,13 +192,17 @@ $ python -m smtpburst --check-dmarc example.com --ping-test example.com > report
 
 ## Development
 
-Install the additional tools for linting and running tests:
+Install the additional tools for linting and running tests and install the
+package in editable mode:
 
 ```bash
 $ pip install -r requirements-dev.txt
+$ pip install -e .
 ```
 
-This installs `pytest` with coverage reporting and `ruff` for code style checks.
+This installs `pytest` with coverage reporting, `ruff` for code style checks and
+the optional dependencies (`dnspython` and `PyYAML`) so that the full test suite
+can run.
 
 ## Running Tests
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
+dnspython
+PyYAML
 pytest
 pytest-cov
 ruff


### PR DESCRIPTION
## Summary
- ensure dnspython and PyYAML are present when developing
- document how to install the package before running tests

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68753a97152c83259b0248c668210f2d