### PR TITLE
Fix Python 3.9 import failures

### DIFF
--- a/smtpburst/attacks/__init__.py
+++ b/smtpburst/attacks/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import socket
 import struct
 import time

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import json
 import warnings

--- a/smtpburst/inbox/__init__.py
+++ b/smtpburst/inbox/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import imaplib
 import poplib
 from typing import List

--- a/smtpburst/send.py
+++ b/smtpburst/send.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import smtplib
 import socket  # noqa: F401 - used by tests for monkeypatching
 import time


### PR DESCRIPTION
## Summary
- future-annotate modules that use union types

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880987db2608325b959f33f0beba3bb