### PR TITLE
feat: add pipeline action registration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -190,6 +190,27 @@ Run a DNS check and save the report:
 $ python -m smtpburst --check-dmarc example.com --ping-test example.com > report.txt
 ```
 
+## Pipeline Actions
+
+`smtpburst` includes a lightweight pipeline runner for chaining discovery and
+attack actions. Pipelines are defined in YAML files with each step specifying an
+`action` and keyword arguments for that action.
+
+Custom actions can be added at runtime using
+`smtpburst.pipeline.register_action(name, func)`. The registered callable will be
+invoked when a pipeline step references its name:
+
+```python
+from smtpburst import pipeline
+
+def greet(name: str) -> str:
+    return f"hello {name}"
+
+pipeline.register_action("greet", greet)
+runner = pipeline.PipelineRunner([{"action": "greet", "name": "alice"}])
+print(runner.run())  # ['hello alice']
+```
+
 ## Development
 
 Install the additional tools for linting and running tests and install the

--- a/smtpburst/pipeline.py
+++ b/smtpburst/pipeline.py
@@ -16,33 +16,41 @@ from .discovery import nettests, tls_probe, ssl_probe
 logger = logging.getLogger(__name__)
 
 
-ACTION_MAP: Dict[str, Callable[..., Any]] = {
-    "check_dmarc": discovery.check_dmarc,
-    "check_spf": discovery.check_spf,
-    "check_dkim": discovery.check_dkim,
-    "check_srv": discovery.check_srv,
-    "check_soa": discovery.check_soa,
-    "check_txt": discovery.check_txt,
-    "lookup_mx": discovery.lookup_mx,
-    "smtp_extensions": discovery.smtp_extensions,
-    "cert_check": discovery.check_certificate,
-    "port_scan": discovery.port_scan,
-    "probe_honeypot": discovery.probe_honeypot,
-    "tls_discovery": tls_probe.discover,
-    "ssl_discovery": ssl_probe.discover,
-    "open_relay_test": nettests.open_relay_test,
-    "ping": nettests.ping,
-    "traceroute": nettests.traceroute,
-    "vrfy_enum": nettests.vrfy_enum,
-    "expn_enum": nettests.expn_enum,
-    "rcpt_enum": nettests.rcpt_enum,
-    "open_sockets": send.open_sockets,
-    "send": send.bombing_mode,
-    "tcp_syn_flood": attacks.tcp_syn_flood,
-    "tcp_reset_attack": attacks.tcp_reset_attack,
-    "tcp_reset_flood": attacks.tcp_reset_flood,
-    "smurf_test": attacks.smurf_test,
-}
+ACTION_MAP: Dict[str, Callable[..., Any]] = {}
+
+
+def register_action(name: str, func: Callable[..., Any]) -> None:
+    """Register ``func`` under ``name`` for use in pipelines."""
+
+    ACTION_MAP[name] = func
+
+
+# Register built-in actions
+register_action("check_dmarc", discovery.check_dmarc)
+register_action("check_spf", discovery.check_spf)
+register_action("check_dkim", discovery.check_dkim)
+register_action("check_srv", discovery.check_srv)
+register_action("check_soa", discovery.check_soa)
+register_action("check_txt", discovery.check_txt)
+register_action("lookup_mx", discovery.lookup_mx)
+register_action("smtp_extensions", discovery.smtp_extensions)
+register_action("cert_check", discovery.check_certificate)
+register_action("port_scan", discovery.port_scan)
+register_action("probe_honeypot", discovery.probe_honeypot)
+register_action("tls_discovery", tls_probe.discover)
+register_action("ssl_discovery", ssl_probe.discover)
+register_action("open_relay_test", nettests.open_relay_test)
+register_action("ping", nettests.ping)
+register_action("traceroute", nettests.traceroute)
+register_action("vrfy_enum", nettests.vrfy_enum)
+register_action("expn_enum", nettests.expn_enum)
+register_action("rcpt_enum", nettests.rcpt_enum)
+register_action("open_sockets", send.open_sockets)
+register_action("send", send.bombing_mode)
+register_action("tcp_syn_flood", attacks.tcp_syn_flood)
+register_action("tcp_reset_attack", attacks.tcp_reset_attack)
+register_action("tcp_reset_flood", attacks.tcp_reset_flood)
+register_action("smurf_test", attacks.smurf_test)
 
 
 class PipelineError(Exception):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -33,8 +33,9 @@ def test_pipeline_runner_stop(monkeypatch, tmp_path):
         calls.append("bad")
         return False
 
-    monkeypatch.setitem(pipeline.ACTION_MAP, "ok", lambda: ok())
-    monkeypatch.setitem(pipeline.ACTION_MAP, "bad", lambda: bad())
+    monkeypatch.setattr(pipeline, "ACTION_MAP", {})
+    pipeline.register_action("ok", lambda: ok())
+    pipeline.register_action("bad", lambda: bad())
 
     cfg = {
         "steps": [
@@ -98,8 +99,9 @@ def test_pipeline_runner_stop_threshold(monkeypatch, tmp_path):
         calls.append("ok")
         return True
 
-    monkeypatch.setitem(pipeline.ACTION_MAP, "bad", lambda: bad())
-    monkeypatch.setitem(pipeline.ACTION_MAP, "ok", lambda: ok())
+    monkeypatch.setattr(pipeline, "ACTION_MAP", {})
+    pipeline.register_action("bad", lambda: bad())
+    pipeline.register_action("ok", lambda: ok())
 
     cfg = {
         "steps": [
@@ -132,3 +134,12 @@ def test_pipeline_step_not_mapping(tmp_path):
     runner = pipeline.load_pipeline(str(path))
     with pytest.raises(pipeline.PipelineError, match="mapping"):
         runner.run()
+
+
+def test_dynamic_action_registration(monkeypatch):
+    monkeypatch.setattr(pipeline, "ACTION_MAP", {})
+
+    pipeline.register_action("mul", lambda value: value * 2)
+
+    runner = pipeline.PipelineRunner([{"action": "mul", "value": 4}])
+    assert runner.run() == [8]


### PR DESCRIPTION
## Summary
- allow pipeline actions to be registered dynamically with `register_action`
- document custom pipeline action registration
- cover dynamic registration with new unit test

## Testing
- `ruff check smtpburst/pipeline.py tests/test_pipeline.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ce22a02348325b85c6a0ba0395266