### PR TITLE
Handle partial stream reads in binary generator

### DIFF
--- a/tests/test_datagen.py
+++ b/tests/test_datagen.py
@@ -24,3 +24,29 @@ def test_generate_secure_ascii_uses_system_random(monkeypatch):
 def test_generate_negative_size():
     with pytest.raises(ValueError):
         datagen.generate(-1)
+
+
+def test_gen_binary_stream_partial(monkeypatch):
+    class PartialStream:
+        def __init__(self, chunks):
+            self.chunks = list(chunks)
+
+        def read(self, n):
+            return self.chunks.pop(0) if self.chunks else b""
+
+    stream = PartialStream([b"ab", b"c"])
+    monkeypatch.setattr(datagen.random, "getrandbits", lambda n: ord("x"))
+    assert datagen.gen_binary(5, stream=stream) == b"abcxx"
+
+
+def test_gen_binary_stream_partial_secure(monkeypatch):
+    class PartialStream:
+        def __init__(self, chunks):
+            self.chunks = list(chunks)
+
+        def read(self, n):
+            return self.chunks.pop(0) if self.chunks else b""
+
+    stream = PartialStream([b"ab"])
+    monkeypatch.setattr(secrets, "token_bytes", lambda n: b"x" * n)
+    assert datagen.gen_binary(4, secure=True, stream=stream) == b"abxx"


### PR DESCRIPTION
## Summary
- replace recursive stream handling with iterative loop in `gen_binary`
- add tests for partial stream data with secure and insecure modes

## Testing
- `pytest tests/test_datagen.py`


------
https://chatgpt.com/codex/tasks/task_e_689cf7816b988325bdb78de551b2e16f