### PR TITLE
Use argparse public APIs for CLI config detection

### DIFF
--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -375,8 +375,9 @@ def parse_args(args=None, cfg: Config | None = None) -> argparse.Namespace:
             config_data = load_config(config_args.config)
         except FileNotFoundError:
             raise SystemExit(f"Config file not found: {config_args.config}")
-        known = {action.dest for action in parser._actions}
-        unknown = [k for k in config_data.keys() if k not in known]
+        # Derive known option names using the public parse_args API
+        defaults = vars(parser.parse_args([]))
+        unknown = [k for k in config_data.keys() if k not in defaults]
         if unknown:
             warnings.warn(
                 f"Unknown config options: {', '.join(unknown)}",


### PR DESCRIPTION
## Summary
- derive known option names via `vars(parser.parse_args([]))` instead of private `_actions`
- add test ensuring parse_args uses public method for unknown config warning

## Testing
- `pytest tests/test_cli_config.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cf774ef2c8325a6e55c343785a2d1