### PR TITLE
Skip unreadable attachment files in send.append_message

### DIFF
--- a/smtpburst/send.py
+++ b/smtpburst/send.py
@@ -88,7 +88,11 @@ def append_message(cfg: Config, attachments: Optional[List[str]] = None) -> byte
 
     if attachments:
         for path in attachments:
-            data = Path(path).read_bytes()
+            try:
+                data = Path(path).read_bytes()
+            except (FileNotFoundError, OSError) as err:
+                logger.warning("Skipping attachment %s: %s", path, err)
+                continue
             ctype, _ = mimetypes.guess_type(path)
             if ctype:
                 maintype, subtype = ctype.split("/", 1)

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -2,6 +2,7 @@ import pytest
 import types
 import smtpburst.send as send
 from smtpburst.config import Config
+import logging
 
 
 def test_send_test_email(monkeypatch):
@@ -44,6 +45,17 @@ def test_send_test_email(monkeypatch):
 def test_parse_server_matrix(server, host, port):
     """Verify parse_server with IPv4, IPv6 and malformed inputs."""
     assert send.parse_server(server) == (host, port)
+
+
+def test_append_message_missing_attachment(tmp_path, caplog):
+    cfg = Config()
+    cfg.SB_SIZE = 0
+    missing = tmp_path / "missing.txt"
+    with caplog.at_level(logging.WARNING):
+        msg = send.append_message(cfg, attachments=[str(missing)])
+    assert isinstance(msg, bytes)
+    assert str(missing) in caplog.text
+    assert missing.name not in msg.decode("utf-8", errors="ignore")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- avoid crashing when attachment files are missing or unreadable by logging a warning and skipping the file
- test that invalid attachment paths don't break message generation

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cfae1c468832581319298bf3cb8f0