### PR TITLE
Add command checks and timeouts for nettests

### DIFF
--- a/tests/test_nettests_timeout.py
+++ b/tests/test_nettests_timeout.py
@@ -1,0 +1,25 @@
+import subprocess
+
+from smtpburst.discovery import nettests
+
+
+def test_ping_timeout(monkeypatch):
+    monkeypatch.setattr(nettests.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(nettests.shutil, "which", lambda x: "/bin/" + x)
+
+    def fake_run(cmd, capture_output, text, check, timeout):
+        raise subprocess.TimeoutExpired(cmd, timeout)
+
+    monkeypatch.setattr(nettests.subprocess, "run", fake_run)
+    assert nettests.ping("host", timeout=2) == "ping command timed out"
+
+
+def test_traceroute_timeout(monkeypatch):
+    monkeypatch.setattr(nettests.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(nettests.shutil, "which", lambda x: "/bin/" + x)
+
+    def fake_run(cmd, capture_output, text, check, timeout):
+        raise subprocess.TimeoutExpired(cmd, timeout)
+
+    monkeypatch.setattr(nettests.subprocess, "run", fake_run)
+    assert nettests.traceroute("host", timeout=2) == "traceroute command timed out"


### PR DESCRIPTION
## Summary
- ensure ping and traceroute verify command availability via `shutil.which` and return informative messages
- add subprocess timeouts for ping and traceroute to avoid hanging
- cover missing-command and timeout scenarios with new tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d0c0db83c8325b14db7c9bf453baf