### PR TITLE
Handle connection errors in inbox search

### DIFF
--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -4,6 +4,8 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from smtpburst import inbox
+import imaplib
+import poplib
 
 
 def test_imap_search(monkeypatch):
@@ -60,3 +62,59 @@ def test_pop3_search(monkeypatch):
     monkeypatch.setattr(inbox.poplib, "POP3_SSL", DummyPOP)
     ids = inbox.pop3_search("host", "u", "p", pattern=b"abc")
     assert ids == [1, 2]
+
+
+def test_imap_search_error(monkeypatch):
+    closed = {"closed": False}
+
+    class DummyIMAP:
+        def __init__(self, host, port):
+            pass
+
+        def login(self, user, pwd):
+            raise imaplib.IMAP4.error("auth failed")
+
+        def select(self, mbox):
+            raise AssertionError("should not be called")
+
+        def search(self, charset, criteria):
+            raise AssertionError("should not be called")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            closed["closed"] = True
+
+    monkeypatch.setattr(inbox.imaplib, "IMAP4_SSL", DummyIMAP)
+    ids = inbox.imap_search("host", "u", "p")
+    assert ids == []
+    assert closed["closed"]
+
+
+def test_pop3_search_error(monkeypatch):
+    closed = {"quit": False}
+
+    class DummyPOP:
+        def __init__(self, host, port):
+            pass
+
+        def user(self, u):
+            raise OSError("network")
+
+        def pass_(self, p):
+            raise AssertionError("should not be called")
+
+        def list(self):
+            raise AssertionError("should not be called")
+
+        def retr(self, i):
+            raise AssertionError("should not be called")
+
+        def quit(self):
+            closed["quit"] = True
+
+    monkeypatch.setattr(inbox.poplib, "POP3_SSL", DummyPOP)
+    ids = inbox.pop3_search("host", "u", "p", pattern=b"abc")
+    assert ids == []
+    assert closed["quit"]


### PR DESCRIPTION
## Summary
- Catch IMAP/POP connection errors and return empty results
- Ensure POP3 sessions are always closed
- Add tests for IMAP/POP error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d117d5ac483259f9830e14f84e778