### PR TITLE
Validate proxy order input

### DIFF
--- a/smtpburst/proxy.py
+++ b/smtpburst/proxy.py
@@ -61,9 +61,13 @@ def check_proxy(
 def load_proxies(path: str, order: str = "asc", check: bool = False) -> List[str]:
     """Return list of proxies from ``path`` respecting ``order``.
 
-    If ``check`` is True, invalid proxies are filtered out using
+    ``order`` must be one of ``"asc"``, ``"desc"`` or ``"random"``. If
+    ``check`` is True, invalid proxies are filtered out using
     :func:`check_proxy`.
     """
+    if order not in {"asc", "desc", "random"}:
+        raise ValueError(f"Unsupported order: {order}")
+
     with open(path, "r", encoding="utf-8") as fh:
         proxies = [line.strip() for line in fh if line.strip()]
 
@@ -79,7 +83,12 @@ def load_proxies(path: str, order: str = "asc", check: bool = False) -> List[str
 
 
 def select_proxy(proxies: List[str], order: str, index: int) -> str | None:
-    """Return proxy for ``index`` using ``order`` strategy."""
+    """Return proxy for ``index`` using ``order`` strategy.
+
+    ``order`` must be one of ``"asc"``, ``"desc"`` or ``"random"``.
+    """
+    if order not in {"asc", "desc", "random"}:
+        raise ValueError(f"Unsupported order: {order}")
     if not proxies:
         return None
     if order == "random":

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -6,6 +6,8 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 import logging
 import socket
 
+import pytest
+
 from smtpburst import proxy
 
 
@@ -24,6 +26,17 @@ def test_select_proxy_orders():
     assert proxy.select_proxy(proxies, "desc", 1) == "b"
     p = proxy.select_proxy(proxies, "random", 5)
     assert p in proxies
+
+
+def test_invalid_order(tmp_path):
+    path = tmp_path / "p.txt"
+    path.write_text("a\nb\n")
+
+    with pytest.raises(ValueError):
+        proxy.load_proxies(str(path), order="bad")
+
+    with pytest.raises(ValueError):
+        proxy.select_proxy(["a", "b"], "bad", 0)
 
 
 def test_check_proxy(monkeypatch):


### PR DESCRIPTION
## Summary
- ensure proxy order parameters accept only asc, desc or random
- document valid order values in proxy helpers
- add tests for invalid order handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a241e3f80c8325bed738d1cc4f08fc