### PR TITLE
Ensure gen_binary exhausts streams before padding

### DIFF
--- a/tests/test_datagen.py
+++ b/tests/test_datagen.py
@@ -37,6 +37,8 @@ def test_gen_binary_stream_partial(monkeypatch):
     stream = PartialStream([b"ab", b"c"])
     monkeypatch.setattr(datagen.random, "getrandbits", lambda n: ord("x"))
     assert datagen.gen_binary(5, stream=stream) == b"abcxx"
+    # ensure the stream was fully consumed before random data was added
+    assert stream.chunks == []
 
 
 def test_gen_binary_stream_partial_secure(monkeypatch):
@@ -50,3 +52,38 @@ def test_gen_binary_stream_partial_secure(monkeypatch):
     stream = PartialStream([b"ab"])
     monkeypatch.setattr(secrets, "token_bytes", lambda n: b"x" * n)
     assert datagen.gen_binary(4, secure=True, stream=stream) == b"abxx"
+    # ensure the stream was fully consumed before random data was added
+    assert stream.chunks == []
+
+
+def test_generate_binary_stream_partial(monkeypatch):
+    class PartialStream:
+        def __init__(self, chunks):
+            self.chunks = list(chunks)
+
+        def read(self, n):
+            return self.chunks.pop(0) if self.chunks else b""
+
+    stream = PartialStream([b"ab", b"c"])
+    monkeypatch.setattr(datagen.random, "getrandbits", lambda n: ord("x"))
+    assert (
+        datagen.generate(5, mode=datagen.DataMode.BINARY, stream=stream) == b"abcxx"
+    )
+    assert stream.chunks == []
+
+
+def test_generate_binary_stream_partial_secure(monkeypatch):
+    class PartialStream:
+        def __init__(self, chunks):
+            self.chunks = list(chunks)
+
+        def read(self, n):
+            return self.chunks.pop(0) if self.chunks else b""
+
+    stream = PartialStream([b"ab"])
+    monkeypatch.setattr(secrets, "token_bytes", lambda n: b"x" * n)
+    assert (
+        datagen.generate(4, mode=datagen.DataMode.BINARY, secure=True, stream=stream)
+        == b"abxx"
+    )
+    assert stream.chunks == []


### PR DESCRIPTION
## Summary
- guarantee `gen_binary` continues reading from the provided stream until the requested size is met
- add tests ensuring short streams are fully consumed before padding with random bytes

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2539eab988325820a369eee9f296b