### PR TITLE
Add JSON and YAML report formats with CLI option

### DIFF
--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -7,7 +7,7 @@ from smtpburst import send
 from smtpburst import cli
 from smtpburst import discovery
 from smtpburst.discovery import nettests
-from smtpburst.reporting import ascii_report
+from smtpburst.reporting import ascii_report, json_report, yaml_report
 from smtpburst import inbox
 from smtpburst import attacks
 from smtpburst.datagen import load_wordlist
@@ -18,6 +18,13 @@ logger = logging.getLogger(__name__)
 def main(argv=None):
     cfg = Config()
     args = cli.parse_args(argv, cfg)
+
+    reporters = {
+        "ascii": ascii_report,
+        "json": json_report,
+        "yaml": yaml_report,
+    }
+    report = reporters.get(args.report_format, ascii_report)
 
     if args.silent:
         level = logging.CRITICAL
@@ -95,7 +102,7 @@ def main(argv=None):
         logger.info("Running SMTP login test")
         res = send.login_test(cfg)
         if res:
-            logger.info(ascii_report(res))
+            logger.info(report(res))
         return
 
     if args.auth_test:
@@ -105,7 +112,7 @@ def main(argv=None):
             return
         res = send.auth_test(cfg)
         if res:
-            logger.info(ascii_report(res))
+            logger.info(report(res))
         return
 
     logger.info("Starting smtp-burst")
@@ -200,7 +207,7 @@ def main(argv=None):
         msg = "Reverse DNS: PASS" if ok else "Reverse DNS: FAIL"
         print(msg)
     if results:
-        logger.info(ascii_report(results))
+        logger.info(report(results))
 
 
 if __name__ == "__main__":

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -330,6 +330,14 @@ CLI_OPTIONS: Iterable[CLIOption] = [
             "help": "Show warnings and errors only",
         },
     ),
+    (
+        ("--report-format",),
+        {
+            "choices": ["ascii", "json", "yaml"],
+            "default": "ascii",
+            "help": "Output report format",
+        },
+    ),
 ]
 
 

--- a/smtpburst/reporting/__init__.py
+++ b/smtpburst/reporting/__init__.py
@@ -1,4 +1,14 @@
-from typing import Dict, Any
+"""Utilities for presenting smtp-burst results in various formats."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Callable
+import json
+
+try:  # pragma: no cover - optional dependency
+    import yaml
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None
 
 
 def ascii_report(results: Dict[str, Any]) -> str:
@@ -13,3 +23,27 @@ def ascii_report(results: Dict[str, Any]) -> str:
         lines.append(f"{name:<{width}}: {data}")
     lines.append(border)
     return "\n".join(lines)
+
+
+def json_report(results: Dict[str, Any]) -> str:
+    """Return results encoded as formatted JSON."""
+
+    return json.dumps(results, indent=2, sort_keys=True)
+
+
+def yaml_report(results: Dict[str, Any]) -> str:
+    """Return results encoded as YAML."""
+
+    if yaml is None:
+        raise RuntimeError("PyYAML not installed")
+    # safe_dump adds a trailing newline which is not needed for logs
+    return yaml.safe_dump(results, sort_keys=False).strip()
+
+
+REPORT_FORMATS: Dict[str, Callable[[Dict[str, Any]], str]] = {
+    "ascii": ascii_report,
+    "json": json_report,
+    "yaml": yaml_report,
+}
+
+__all__ = ["ascii_report", "json_report", "yaml_report", "REPORT_FORMATS"]

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,4 +1,12 @@
+import json
 import smtpburst.reporting as reporting
+
+try:  # pragma: no cover - optional dependency
+    import yaml
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None
+
+import pytest
 
 
 def test_ascii_report_long_keys():
@@ -16,3 +24,16 @@ def test_ascii_report_long_keys():
     assert lines[-1] == border
     assert lines[3] == f"short{' ' * (width - len('short'))}: 1"
     assert lines[4] == "this_is_a_really_long_key: 2"
+
+
+def test_json_report_valid():
+    results = {"short": 1, "long": {"nested": 2}}
+    output = reporting.json_report(results)
+    assert json.loads(output) == results
+
+
+@pytest.mark.skipif(yaml is None, reason="PyYAML not installed")
+def test_yaml_report_valid():
+    results = {"short": 1, "long": {"nested": 2}}
+    output = reporting.yaml_report(results)
+    assert yaml.safe_load(output) == results


### PR DESCRIPTION
## Summary
- Support JSON and YAML reporting alongside existing ASCII format
- Add `--report-format` CLI flag to select report output style
- Update tests to validate JSON/YAML outputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a25bc0905c8325a217664499cfeeb1