### PR TITLE
feat: add proxy timeout configuration

### DIFF
--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -68,9 +68,11 @@ def main(argv=None):
             Path(args.proxy_file),
             order=args.proxy_order,
             check=args.check_proxies,
+            timeout=args.proxy_timeout,
         )
     cfg.SB_PROXY_ORDER = args.proxy_order
     cfg.SB_CHECK_PROXIES = args.check_proxies
+    cfg.SB_PROXY_TIMEOUT = args.proxy_timeout
     if args.userlist:
         cfg.SB_USERLIST = load_wordlist(Path(args.userlist))
     if args.passlist:

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -188,6 +188,11 @@ CLI_OPTIONS: Iterable[CLIOption] = [
         "default_attr": "SB_CHECK_PROXIES",
         "help": "Validate proxies before use",
     }),
+    (("--proxy-timeout",), {
+        "type": float,
+        "default_attr": "SB_PROXY_TIMEOUT",
+        "help": "Timeout in seconds when validating proxies",
+    }),
 
     (("--userlist",), {"help": "Username wordlist for SMTP AUTH"}),
     (("--passlist",), {"help": "Password wordlist for SMTP AUTH"}),
@@ -423,6 +428,7 @@ def apply_args_to_config(cfg: Config, args: argparse.Namespace) -> None:
         "starttls": "SB_STARTTLS",
         "proxy_order": "SB_PROXY_ORDER",
         "check_proxies": "SB_CHECK_PROXIES",
+        "proxy_timeout": "SB_PROXY_TIMEOUT",
     }
 
     for arg_name, cfg_attr in MAP.items():

--- a/smtpburst/config.py
+++ b/smtpburst/config.py
@@ -31,6 +31,7 @@ class Config:
     SB_PROXIES: List[str] = field(default_factory=list)
     SB_PROXY_ORDER: str = "asc"
     SB_CHECK_PROXIES: bool = False
+    SB_PROXY_TIMEOUT: float = 5.0
     SB_USERLIST: List[str] = field(default_factory=list)
     SB_PASSLIST: List[str] = field(default_factory=list)
     SB_USERNAME: str = ""


### PR DESCRIPTION
## Summary
- allow specifying timeout when checking proxies and report reason for failures
- expose proxy timeout option via CLI and config
- test proxy timeout handling and logging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a25bbd871483258e1afcef9fece425