### PR TITLE
Validate datagen inputs for dict and repeat modes

### DIFF
--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -125,12 +125,23 @@ CLI_OPTIONS: Iterable[CLIOption] = [
         "default_attr": "SB_DATA_MODE",
         "help": "Payload generation mode",
     }),
-    (("--dict-file",), {"help": "Word list for dictionary mode"}),
+    (
+        ("--dict-file",),
+        {
+            "help": (
+                "Word list for dictionary mode "
+                "(required with --data-mode dict)"
+            )
+        },
+    ),
     (
         ("--repeat-string",),
         {
             "default_attr": "SB_REPEAT_STRING",
-            "help": "String to repeat for repeat mode",
+            "help": (
+                "String to repeat for repeat mode "
+                "(required with --data-mode repeat)"
+            ),
         },
     ),
     (("--per-burst-data",), {

--- a/smtpburst/datagen.py
+++ b/smtpburst/datagen.py
@@ -121,9 +121,17 @@ def generate(
     if mode is DataMode.UTF8:
         return gen_utf8(size, secure=secure).encode("utf-8")
     if mode is DataMode.DICT:
-        return gen_dictionary(size, words or []).encode("utf-8")
+        if not words:
+            raise ValueError(
+                "words list required for dictionary mode; provide --dict-file"
+            )
+        return gen_dictionary(size, words).encode("utf-8")
     if mode is DataMode.REPEAT:
-        return gen_repeat(repeat or "", size).encode("utf-8")
+        if not repeat:
+            raise ValueError(
+                "repeat string required for repeat mode; provide --repeat-string"
+            )
+        return gen_repeat(repeat, size).encode("utf-8")
 
     # default ascii
     return gen_ascii(size, secure=secure).encode("ascii")

--- a/tests/test_datagen.py
+++ b/tests/test_datagen.py
@@ -41,6 +41,20 @@ def test_gen_binary_stream_partial(monkeypatch):
     assert stream.chunks == []
 
 
+def test_generate_dict_requires_words():
+    with pytest.raises(ValueError):
+        datagen.generate(10, mode=datagen.DataMode.DICT, words=None)
+    with pytest.raises(ValueError):
+        datagen.generate(10, mode=datagen.DataMode.DICT, words=[])
+
+
+def test_generate_repeat_requires_string():
+    with pytest.raises(ValueError):
+        datagen.generate(10, mode=datagen.DataMode.REPEAT, repeat=None)
+    with pytest.raises(ValueError):
+        datagen.generate(10, mode=datagen.DataMode.REPEAT, repeat="")
+
+
 def test_gen_binary_stream_partial_secure(monkeypatch):
     class PartialStream:
         def __init__(self, chunks):


### PR DESCRIPTION
## Summary
- raise clear errors when DataMode.DICT or DataMode.REPEAT are used without required inputs
- document CLI requirements for `--dict-file` and `--repeat-string`
- cover new error cases with tests

## Testing
- `flake8 smtpburst/datagen.py smtpburst/cli.py tests/test_datagen.py`
- `pytest tests/test_datagen.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'dns')*

------
https://chatgpt.com/codex/tasks/task_e_68a266e4625083259aa10e505de15c84