### PR TITLE
Allow configurable timeouts for ping and traceroute

### DIFF
--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -179,9 +179,11 @@ def main(argv=None):
         host, port = send.parse_server(args.server)
         results["open_relay"] = nettests.open_relay_test(host, port)
     if args.ping_test:
-        results["ping"] = nettests.ping(args.ping_test)
+        results["ping"] = nettests.ping(args.ping_test, timeout=args.ping_timeout)
     if args.traceroute_test:
-        results["traceroute"] = nettests.traceroute(args.traceroute_test)
+        results["traceroute"] = nettests.traceroute(
+            args.traceroute_test, timeout=args.traceroute_timeout
+        )
     if args.perf_test:
         host, port = send.parse_server(args.perf_test)
         results["performance"] = attacks.performance_test(

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -292,8 +292,20 @@ CLI_OPTIONS: Iterable[CLIOption] = [
         {"help": "Host to ping"},
     ),
     (
+        ("--ping-timeout",),
+        {"type": int, "default": 1, "help": "Ping timeout in seconds"},
+    ),
+    (
         ("--traceroute-test",),
         {"help": "Host to traceroute"},
+    ),
+    (
+        ("--traceroute-timeout",),
+        {
+            "type": int,
+            "default": 5,
+            "help": "Traceroute timeout in seconds",
+        },
     ),
     (
         ("--perf-test",),

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -127,10 +127,25 @@ def test_per_burst_flag():
 
 def test_discovery_options():
     args = burst_cli.parse_args(
-        ["--check-dmarc", "ex.com", "--ping-test", "host"], Config()
+        [
+            "--check-dmarc",
+            "ex.com",
+            "--ping-test",
+            "host",
+            "--ping-timeout",
+            "4",
+            "--traceroute-test",
+            "thost",
+            "--traceroute-timeout",
+            "6",
+        ],
+        Config(),
     )
     assert args.check_dmarc == "ex.com"
     assert args.ping_test == "host"
+    assert args.ping_timeout == 4
+    assert args.traceroute_test == "thost"
+    assert args.traceroute_timeout == 6
 
 
 def test_perf_cli_options():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -182,6 +182,44 @@ def test_main_banner_check(monkeypatch):
     assert called['server'] == 'srv'
 
 
+def test_main_ping_timeout(monkeypatch):
+    called = {}
+
+    def fake_bomb(cfg, attachments=None):
+        pass
+
+    def fake_ping(host, count=1, timeout=1):
+        called["host"] = host
+        called["timeout"] = timeout
+        return "ok"
+
+    monkeypatch.setattr(main_mod.send, "bombing_mode", fake_bomb)
+    monkeypatch.setattr(main_mod.nettests, "ping", fake_ping)
+
+    main_mod.main(["--ping-test", "host", "--ping-timeout", "7"])
+
+    assert called == {"host": "host", "timeout": 7}
+
+
+def test_main_traceroute_timeout(monkeypatch):
+    called = {}
+
+    def fake_bomb(cfg, attachments=None):
+        pass
+
+    def fake_traceroute(host, count=30, timeout=5):
+        called["host"] = host
+        called["timeout"] = timeout
+        return "ok"
+
+    monkeypatch.setattr(main_mod.send, "bombing_mode", fake_bomb)
+    monkeypatch.setattr(main_mod.nettests, "traceroute", fake_traceroute)
+
+    main_mod.main(["--traceroute-test", "host", "--traceroute-timeout", "9"])
+
+    assert called == {"host": "host", "timeout": 9}
+
+
 def test_main_pipeline_error(monkeypatch, capsys):
     def fake_load(path):
         raise pipeline.PipelineError("bad pipeline")


### PR DESCRIPTION
## Summary
- add `--ping-timeout` and `--traceroute-timeout` CLI options
- pass timeout values to `nettests.ping` and `nettests.traceroute`
- test CLI parsing and `__main__` integration for the new timeouts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a266e15d988325b29607ff69ef83b7