### PR TITLE
Reorder network module imports

### DIFF
--- a/smtpburst/discovery/nettests.py
+++ b/smtpburst/discovery/nettests.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from dns import resolver
-import ipaddress
 import smtplib
+import ipaddress
+from dns import resolver
 import subprocess
 import platform
 import shutil


### PR DESCRIPTION
## Summary
- Ensure network test utilities import smtplib, ipaddress, and DNS resolver modules at the top of `nettests`

## Testing
- `python -m py_compile smtpburst/discovery/nettests.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4a0ce99f083259d82289daa1c4afc