### PR TITLE
Handle ping failure output when validating proxies

### DIFF
--- a/smtpburst/proxy.py
+++ b/smtpburst/proxy.py
@@ -25,8 +25,8 @@ def check_proxy(
     handshake to ``proxy`` followed by an optional HTTP CONNECT request.
     """
     ph, pp = parse_server(proxy)
-
-    if not ping(ph):
+    result = ping(ph)
+    if not result or "not found" in result.lower() or "timed out" in result.lower():
         logger.warning("Ping to proxy %s failed", proxy)
         return False
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -90,9 +90,17 @@ def test_check_proxy_failure(monkeypatch, caplog):
         assert "Ping" in caplog.text
 
 
+@pytest.mark.parametrize("msg", ["ping command not found", "ping command timed out"])
+def test_check_proxy_ping_errors(monkeypatch, caplog, msg):
+    monkeypatch.setattr(proxy, "ping", lambda h: msg)
+    with caplog.at_level(logging.WARNING):
+        assert not proxy.check_proxy("bad:1")
+        assert "Ping" in caplog.text
+
+
 def test_check_proxy_bad_status(monkeypatch):
     def fake_ping(host):
-        return True
+        return "pong"
 
     class DummySock:
         def __enter__(self):
@@ -133,7 +141,7 @@ def test_load_proxies_timeout(monkeypatch, tmp_path):
 
 def test_check_proxy_timeout(monkeypatch, caplog):
     def fake_ping(host):
-        return True
+        return "pong"
 
     class DummySock:
         def __enter__(self):


### PR DESCRIPTION
## Summary
- Treat ping command not found and timed-out messages as proxy validation failures
- Test proxy validation logic against ping error messages

## Testing
- `ruff check smtpburst/proxy.py tests/test_proxy.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7411a271c8325af95226d44d2f4e0