### PR TITLE
feat(cli): add timeout option

### DIFF
--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -87,6 +87,12 @@ CLI_OPTIONS: Iterable[CLIOption] = [
         "help": "Latency in seconds considered a tarpit",
     }),
 
+    (("--timeout",), {
+        "type": float,
+        "default_attr": "SB_TIMEOUT",
+        "help": "Timeout in seconds for network operations",
+    }),
+
     (("--open-sockets",), {
         "type": int,
         "default": 0,
@@ -444,6 +450,7 @@ def apply_args_to_config(cfg: Config, args: argparse.Namespace) -> None:
         "global_delay": "SB_GLOBAL_DELAY",
         "socket_delay": "SB_OPEN_SOCKETS_DELAY",
         "tarpit_threshold": "SB_TARPIT_THRESHOLD",
+        "timeout": "SB_TIMEOUT",
         "size": "SB_SIZE",
         "data_mode": "SB_DATA_MODE",
         "repeat_string": "SB_REPEAT_STRING",

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -120,6 +120,13 @@ def test_new_delay_options():
     assert args.tarpit_threshold == 3
 
 
+def test_timeout_applies_to_config():
+    args = burst_cli.parse_args(["--timeout", "7"], Config())
+    cfg = Config()
+    burst_cli.apply_args_to_config(cfg, args)
+    assert cfg.SB_TIMEOUT == 7
+
+
 def test_per_burst_flag():
     args = burst_cli.parse_args(["--per-burst-data"], Config())
     assert args.per_burst_data


### PR DESCRIPTION
## Summary
- add `--timeout` CLI option mapped to `Config.SB_TIMEOUT`
- ensure `apply_args_to_config` populates timeout
- cover timeout behavior with new test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac99cdddcc8325bbffbd225c2685ad