### PR TITLE
Add report file output option

### DIFF
--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -211,7 +211,10 @@ def main(argv=None):
         msg = "Reverse DNS: PASS" if ok else "Reverse DNS: FAIL"
         print(msg)
     if results:
-        logger.info(report(results))
+        formatted = report(results)
+        logger.info(formatted)
+        if args.report_file:
+            Path(args.report_file).write_text(formatted, encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -372,6 +372,7 @@ CLI_OPTIONS: Iterable[CLIOption] = [
             "help": "Output report format",
         },
     ),
+    (("--report-file",), {"metavar": "FILE", "help": "Write report to FILE"}),
 ]
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -230,3 +230,20 @@ def test_main_pipeline_error(monkeypatch, capsys):
 
     out = capsys.readouterr().out
     assert "bad pipeline" in out
+
+
+def test_report_file(monkeypatch, tmp_path):
+    def fake_bomb(cfg, attachments=None):
+        pass
+
+    def fake_ping(host, count=1, timeout=1):
+        return "pong"
+
+    monkeypatch.setattr(main_mod.send, "bombing_mode", fake_bomb)
+    monkeypatch.setattr(main_mod.nettests, "ping", fake_ping)
+
+    out_file = tmp_path / "report.txt"
+    main_mod.main(["--ping-test", "host", "--report-file", str(out_file)])
+
+    expected = main_mod.ascii_report({"ping": "pong"})
+    assert out_file.read_text() == expected


### PR DESCRIPTION
## Summary
- Add `--report-file` CLI flag to save discovery results to a file
- Write formatted results to the file when provided
- Test that the CLI flag writes the expected report

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aca898e404832581d14bfc5dc90e56