### PR TITLE
Handle IPv6 ping commands and tests

### DIFF
--- a/tests/test_nettests_timeout.py
+++ b/tests/test_nettests_timeout.py
@@ -23,3 +23,70 @@ def test_traceroute_timeout(monkeypatch):
 
     monkeypatch.setattr(nettests.subprocess, "run", fake_run)
     assert nettests.traceroute("host", timeout=2) == "traceroute command timed out"
+
+
+def test_ping_ipv6_prefers_ping6(monkeypatch):
+    monkeypatch.setattr(nettests.platform, "system", lambda: "Linux")
+
+    def which(cmd):
+        return "/bin/" + cmd if cmd in {"ping", "ping6"} else None
+
+    monkeypatch.setattr(nettests.shutil, "which", which)
+    called = {}
+
+    def fake_run(cmd, capture_output, text, check, timeout):
+        called["cmd"] = cmd
+
+        class Result:
+            returncode = 0
+            stdout = ""
+        return Result()
+
+    monkeypatch.setattr(nettests.subprocess, "run", fake_run)
+    nettests.ping("::1")
+    assert called["cmd"][0] == "ping6"
+
+
+def test_ping_ipv6_uses_dash6(monkeypatch):
+    monkeypatch.setattr(nettests.platform, "system", lambda: "Linux")
+
+    def which(cmd):
+        return "/bin/" + cmd if cmd == "ping" else None
+
+    monkeypatch.setattr(nettests.shutil, "which", which)
+    called = {}
+
+    def fake_run(cmd, capture_output, text, check, timeout):
+        called["cmd"] = cmd
+
+        class Result:
+            returncode = 0
+            stdout = ""
+        return Result()
+
+    monkeypatch.setattr(nettests.subprocess, "run", fake_run)
+    nettests.ping("2001:db8::1")
+    assert called["cmd"][0] == "ping"
+    assert "-6" in called["cmd"]
+
+
+def test_ping_ipv6_windows(monkeypatch):
+    monkeypatch.setattr(nettests.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(nettests.shutil, "which", lambda x: x)
+    called = {}
+
+    def fake_run(cmd, capture_output, text, check, timeout):
+        called["cmd"] = cmd
+
+        class Result:
+            returncode = 0
+            stdout = ""
+        return Result()
+
+    monkeypatch.setattr(nettests.subprocess, "run", fake_run)
+    nettests.ping("fe80::1")
+    assert called["cmd"][0] == "ping"
+    assert "-6" in called["cmd"]
+    assert "-n" in called["cmd"]
+    assert "-w" in called["cmd"]
+    assert called["cmd"][-1] == "fe80::1"


### PR DESCRIPTION
## Summary
- Detect IPv6 addresses and choose suitable ping command
- Preserve Windows flags when pinging IPv6
- Add unit tests for IPv6 ping command selection

## Testing
- `flake8 smtpburst/discovery/nettests.py tests/test_nettests_timeout.py`
- `python -m pytest tests/test_nettests_timeout.py`


------
https://chatgpt.com/codex/tasks/task_e_68acad2be2448325a4be5dd7dfcd03d8