### PR TITLE
Include banner and RDNS results in reports

### DIFF
--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -203,13 +203,11 @@ def main(argv=None):
         from smtpburst.discovery import rdns
 
         ok = rdns.verify(host)
-        msg = "Reverse DNS: PASS" if ok else "Reverse DNS: FAIL"
-        print(msg)
+        results["reverse_dns"] = "PASS" if ok else "FAIL"
     if args.banner_check:
         banner, ok = discovery.banner_check(args.server)
-        print(f"Banner: {banner}")
-        msg = "Reverse DNS: PASS" if ok else "Reverse DNS: FAIL"
-        print(msg)
+        results["banner"] = banner
+        results["reverse_dns"] = "PASS" if ok else "FAIL"
     if results:
         formatted = report(results)
         logger.info(formatted)

--- a/tests/test_banner.py
+++ b/tests/test_banner.py
@@ -55,3 +55,26 @@ def test_banner_check_rdns_fail(monkeypatch):
     banner, ok = discovery.banner_check("host")
     assert banner == "220 test"
     assert not ok
+
+
+from smtpburst import __main__ as main_mod
+
+
+def test_main_banner_check_report(monkeypatch):
+    called = {}
+
+    def fake_banner_check(server):
+        called["server"] = server
+        return ("banner", True)
+
+    def fake_report(res):
+        called["report"] = res
+        return "formatted"
+
+    monkeypatch.setattr(main_mod.discovery, "banner_check", fake_banner_check)
+    monkeypatch.setattr(main_mod, "ascii_report", fake_report)
+
+    main_mod.main(["--banner-check", "--server", "srv"])
+
+    assert called["server"] == "srv"
+    assert called["report"] == {"banner": "banner", "reverse_dns": "PASS"}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -175,11 +175,37 @@ def test_main_banner_check(monkeypatch):
         called['server'] = server
         return ('banner', True)
 
+    def fake_report(res):
+        called['report'] = res
+        return 'formatted'
+
     monkeypatch.setattr(main_mod.discovery, 'banner_check', fake_banner_check)
+    monkeypatch.setattr(main_mod, 'ascii_report', fake_report)
 
     main_mod.main(['--banner-check', '--server', 'srv'])
 
     assert called['server'] == 'srv'
+    assert called['report'] == {'banner': 'banner', 'reverse_dns': 'PASS'}
+
+
+def test_main_rdns_test(monkeypatch):
+    called = {}
+
+    def fake_verify(host):
+        called['host'] = host
+        return True
+
+    def fake_report(res):
+        called['report'] = res
+        return 'formatted'
+
+    monkeypatch.setattr(main_mod.discovery.rdns, 'verify', fake_verify)
+    monkeypatch.setattr(main_mod, 'ascii_report', fake_report)
+
+    main_mod.main(['--rdns-test', '--server', 'host'])
+
+    assert called['host'] == 'host'
+    assert called['report'] == {'reverse_dns': 'PASS'}
 
 
 def test_main_ping_timeout(monkeypatch):


### PR DESCRIPTION
## Summary
- Capture reverse-DNS and banner check results in `main()` and include them in report output
- Add regression tests for banner and RDNS reporting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adfbe6e0f48325b806a3a302a0c841