### PR TITLE
Add HTML HTML body support for emails

### DIFF
--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -90,6 +90,8 @@ def main(argv=None):
         cfg.SB_PASSWORD = args.password
     if args.body_file:
         cfg.SB_BODY = Path(args.body_file).read_text(encoding="utf-8")
+    if args.html_body_file:
+        cfg.SB_HTML_BODY = Path(args.html_body_file).read_text(encoding="utf-8")
     if args.template_file:
         cfg.SB_TEMPLATE = Path(args.template_file).read_text(encoding="utf-8")
     if args.enum_list:

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -39,6 +39,7 @@ CLI_OPTIONS: Iterable[CLIOption] = [
     }),
     (("--subject",), {"default_attr": "SB_SUBJECT", "help": "Email subject line"}),
     (("--body-file",), {"help": "File containing email body text"}),
+    (("--html-body-file",), {"help": "File containing HTML body text"}),
     (
         ("--attach",),
         {
@@ -474,6 +475,7 @@ def apply_args_to_config(cfg: Config, args: argparse.Namespace) -> None:
         "proxy_order": "SB_PROXY_ORDER",
         "check_proxies": "SB_CHECK_PROXIES",
         "proxy_timeout": "SB_PROXY_TIMEOUT",
+        "html_body_file": "SB_HTML_BODY",
     }
 
     for arg_name, cfg_attr in MAP.items():

--- a/smtpburst/config.py
+++ b/smtpburst/config.py
@@ -26,6 +26,7 @@ class Config:
     SB_SERVER: str = "smtp.mail.com"
     SB_SUBJECT: str = "smtp-burst test"
     SB_BODY: str = "smtp-burst message body"
+    SB_HTML_BODY: str = ""
     SB_TEMPLATE: str = ""
 
     # Proxy and authentication defaults

--- a/smtpburst/send.py
+++ b/smtpburst/send.py
@@ -81,6 +81,8 @@ def append_message(cfg: Config, attachments: Optional[List[str]] = None) -> byte
         msg["X-Orig"] = "overlap"
 
     msg.set_content(payload, maintype="text", subtype="plain", cte="8bit")
+    if cfg.SB_HTML_BODY:
+        msg.add_alternative(cfg.SB_HTML_BODY, subtype="html")
 
     if attachments:
         for path in attachments:

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -89,6 +89,13 @@ def test_body_file_option(tmp_path):
     assert args.body_file == str(body_file)
 
 
+def test_html_body_file_option(tmp_path):
+    body_file = tmp_path / "body.html"
+    body_file.write_text("<p>hello</p>")
+    args = burst_cli.parse_args(["--html-body-file", str(body_file)], Config())
+    assert args.html_body_file == str(body_file)
+
+
 def test_attach_option(tmp_path):
     f1 = tmp_path / "a.txt"
     f2 = tmp_path / "b.txt"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -504,6 +504,26 @@ def test_append_message_uses_subject_and_body(monkeypatch):
     assert b"Body" in msg
 
 
+def test_append_message_html_body():
+    cfg = Config()
+    cfg.SB_SENDER = "a@b.com"
+    cfg.SB_RECEIVERS = ["c@d.com"]
+    cfg.SB_SUBJECT = "Sub"
+    cfg.SB_BODY = "Body"
+    cfg.SB_HTML_BODY = "<p>HTML</p>"
+    cfg.SB_SIZE = 0
+    msg_bytes = burstGen.append_message(cfg)
+    import email
+
+    msg = email.message_from_bytes(msg_bytes)
+    assert msg.is_multipart()
+    # first part is plain text with body, second part is html
+    parts = msg.get_payload()
+    assert len(parts) == 2
+    assert parts[1].get_content_type() == "text/html"
+    assert "<p>HTML</p>" in parts[1].get_payload()
+
+
 def test_append_message_template():
     cfg = Config()
     cfg.SB_SENDER = "a@b.com"


### PR DESCRIPTION
## Summary
- allow specifying an HTML body file via --html-body-file
- store HTML body content in config and include as alternative part when sending
- add tests for HTML body option and message construction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae01f04dcc83258564c32496c0a351