### PR TITLE
Reorder EHLO and STARTTLS handshake

### DIFF
--- a/smtpburst/send.py
+++ b/smtpburst/send.py
@@ -226,12 +226,16 @@ def sendmail(
         throttle(cfg)
         try:
             with smtp_cls(host, port, timeout=cfg.SB_TIMEOUT) as smtpObj:
-                if start_tls and not use_ssl:
-                    smtpObj.starttls()
                 if cfg.SB_HELO_HOST:
                     smtpObj.ehlo(cfg.SB_HELO_HOST)
                 else:
                     smtpObj.ehlo()
+                if start_tls and not use_ssl:
+                    smtpObj.starttls()
+                    if cfg.SB_HELO_HOST:
+                        smtpObj.ehlo(cfg.SB_HELO_HOST)
+                    else:
+                        smtpObj.ehlo()
                 if users and passwords:
                     success = False
                     for user in users:


### PR DESCRIPTION
## Summary
- send EHLO immediately on connection and renegotiate after STARTTLS
- add test ensuring STARTTLS triggers EHLO renegotiation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b605288cd083259c8a824674d4a278