### PR TITLE
Raise CommandNotFoundError for missing network utilities

### DIFF
--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -181,11 +181,19 @@ def main(argv=None):
         host, port = send.parse_server(args.server)
         results["open_relay"] = nettests.open_relay_test(host, port)
     if args.ping_test:
-        results["ping"] = nettests.ping(args.ping_test, timeout=args.ping_timeout)
+        try:
+            results["ping"] = nettests.ping(
+                args.ping_test, timeout=args.ping_timeout
+            )
+        except nettests.CommandNotFoundError as exc:
+            results["ping"] = str(exc)
     if args.traceroute_test:
-        results["traceroute"] = nettests.traceroute(
-            args.traceroute_test, timeout=args.traceroute_timeout
-        )
+        try:
+            results["traceroute"] = nettests.traceroute(
+                args.traceroute_test, timeout=args.traceroute_timeout
+            )
+        except nettests.CommandNotFoundError as exc:
+            results["traceroute"] = str(exc)
     if args.perf_test:
         host, port = send.parse_server(args.perf_test)
         results["performance"] = attacks.performance_test(

--- a/smtpburst/discovery/nettests.py
+++ b/smtpburst/discovery/nettests.py
@@ -12,11 +12,19 @@ from typing import Callable, Dict, List
 
 
 class CommandNotFoundError(Exception):
-    """Raised when required network command is unavailable."""
+    """Raised when a required network command is unavailable."""
+
+    def __init__(self, cmd: str):
+        super().__init__(f"{cmd} command not found")
+        self.cmd = cmd
 
 
 def ping(host: str, count: int = 1, timeout: int = 1) -> str:
-    """Return output of ``ping`` command for ``host``."""
+    """Return output of ``ping`` command for ``host``.
+
+    Raises:
+        CommandNotFoundError: If the ``ping`` command is unavailable.
+    """
     is_windows = platform.system().lower() == "windows"
     ipv6 = False
     try:
@@ -38,7 +46,7 @@ def ping(host: str, count: int = 1, timeout: int = 1) -> str:
         else:
             cmd = ["ping", "-c", str(count), "-W", str(timeout), host]
     if shutil.which(cmd[0]) is None:  # pragma: no cover - depends on environment
-        return f"{cmd[0]} command not found"
+        raise CommandNotFoundError(cmd[0])
     try:
         proc = subprocess.run(
             cmd,
@@ -57,7 +65,11 @@ def ping(host: str, count: int = 1, timeout: int = 1) -> str:
 
 
 def traceroute(host: str, count: int = 30, timeout: int = 5) -> str:
-    """Return output of ``traceroute`` command for ``host``."""
+    """Return output of ``traceroute`` command for ``host``.
+
+    Raises:
+        CommandNotFoundError: If the ``traceroute`` command is unavailable.
+    """
     cmd = ["traceroute", "-m", str(count), "-w", str(timeout), host]
     if platform.system().lower() == "windows":
         cmd = [
@@ -69,7 +81,7 @@ def traceroute(host: str, count: int = 30, timeout: int = 5) -> str:
             host,
         ]
     if shutil.which(cmd[0]) is None:  # pragma: no cover - depends on environment
-        return f"{cmd[0]} command not found"
+        raise CommandNotFoundError(cmd[0])
     try:
         proc = subprocess.run(
             cmd,

--- a/smtpburst/proxy.py
+++ b/smtpburst/proxy.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import List, Optional
 from urllib.parse import urlsplit
 
-from .discovery.nettests import ping
+from .discovery.nettests import CommandNotFoundError, ping
 
 logger = logging.getLogger(__name__)
 
@@ -60,8 +60,12 @@ def check_proxy(
     but is preserved in the returned :class:`ProxyInfo` object.
     """
     info = parse_proxy(proxy)
-    result = ping(info.host)
-    if not result or "not found" in result.lower() or "timed out" in result.lower():
+    try:
+        result = ping(info.host)
+    except CommandNotFoundError:
+        logger.warning("Ping to proxy %s failed", proxy)
+        return None
+    if not result or "timed out" in result.lower():
         logger.warning("Ping to proxy %s failed", proxy)
         return None
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -3,6 +3,8 @@ import os
 import sys
 from types import SimpleNamespace
 
+import pytest
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from smtpburst import discovery
@@ -82,7 +84,8 @@ def test_ping_missing_command(monkeypatch):
         called = True
 
     monkeypatch.setattr(nettests.subprocess, "run", fake_run)
-    assert nettests.ping("host") == "ping command not found"
+    with pytest.raises(nettests.CommandNotFoundError, match="ping"):
+        nettests.ping("host")
     assert not called
 
 
@@ -121,7 +124,8 @@ def test_traceroute_missing_command(monkeypatch):
         called = True
 
     monkeypatch.setattr(nettests.subprocess, "run", fake_run)
-    assert nettests.traceroute("host") == "traceroute command not found"
+    with pytest.raises(nettests.CommandNotFoundError, match="traceroute"):
+        nettests.traceroute("host")
     assert not called
 
 


### PR DESCRIPTION
## Summary
- raise `CommandNotFoundError` in `ping` and `traceroute` when required binaries are absent
- handle `CommandNotFoundError` in proxy checks and CLI entry point
- update tests and docs for new exception behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6244aa88483259561bbc9ff35a9b3