### PR TITLE
Handle invalid proxies in proxy checks

### DIFF
--- a/smtpburst/proxy.py
+++ b/smtpburst/proxy.py
@@ -59,7 +59,11 @@ def check_proxy(
     Authentication information in ``proxy`` is ignored during the validation
     but is preserved in the returned :class:`ProxyInfo` object.
     """
-    info = parse_proxy(proxy)
+    try:
+        info = parse_proxy(proxy)
+    except ValueError as exc:
+        logger.warning("Invalid proxy %s: %s", proxy, exc)
+        return None
     try:
         result = ping(info.host)
     except CommandNotFoundError:


### PR DESCRIPTION
## Summary
- log and skip malformed proxies in `check_proxy`
- test that `load_proxies` ignores bad proxy entries when `check=True`

## Testing
- `flake8 smtpburst/proxy.py tests/test_proxy.py`
- `pytest -q`
- `pytest tests/test_proxy.py::test_load_proxies_malformed_proxy_ignored -q`

------
https://chatgpt.com/codex/tasks/task_e_68b628c231ac8325b59b141aed1a2431