### PR TITLE
Use POP3 stat for message count

### DIFF
--- a/smtpburst/inbox/__init__.py
+++ b/smtpburst/inbox/__init__.py
@@ -46,7 +46,7 @@ def pop3_search(
         pop.user(user)
         pop.pass_(password)
         ids: List[int] = []
-        count = len(pop.list()[1])
+        count, _ = pop.stat()
         for i in range(1, count + 1):
             resp, lines, _ = pop.retr(i)
             msg = b"\n".join(lines)

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -37,6 +37,8 @@ def test_imap_search(monkeypatch):
 
 
 def test_pop3_search(monkeypatch):
+    called = {"stat": False}
+
     class DummyPOP:
         def __init__(self, host, port):
             assert host == "host"
@@ -49,8 +51,9 @@ def test_pop3_search(monkeypatch):
         def pass_(self, p):
             assert p == "p"
 
-        def list(self):
-            return (b"+OK", [b"1 0", b"2 0"])
+        def stat(self):
+            called["stat"] = True
+            return (2, 0)
 
         def retr(self, i):
             return (b"+OK", [self.msgs[i]], len(self.msgs[i]))
@@ -61,6 +64,7 @@ def test_pop3_search(monkeypatch):
     monkeypatch.setattr(inbox.poplib, "POP3_SSL", DummyPOP)
     ids = inbox.pop3_search("host", "u", "p", pattern=b"abc")
     assert ids == [1, 2]
+    assert called["stat"]
 
 
 def test_imap_search_error(monkeypatch):


### PR DESCRIPTION
## Summary
- switch POP3 search to use `stat()` for message counting
- update tests to cover `stat()` usage

## Testing
- `pytest tests/test_inbox.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6db8d308c8325826ae918e1214130