### PR TITLE
Raise error on invalid data mode and surface via CLI

### DIFF
--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -120,10 +120,14 @@ def main(argv=None):
         return
 
     logger.info("Starting smtp-burst")
-    if args.async_mode:
-        asyncio.run(send.async_bombing_mode(cfg, attachments=args.attach))
-    else:
-        send.bombing_mode(cfg, attachments=args.attach)
+    try:
+        if args.async_mode:
+            asyncio.run(send.async_bombing_mode(cfg, attachments=args.attach))
+        else:
+            send.bombing_mode(cfg, attachments=args.attach)
+    except ValueError as exc:
+        logger.error(exc)
+        return
 
     results = {}
     if args.check_dmarc:

--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -127,7 +127,7 @@ def main(argv=None):
             send.bombing_mode(cfg, attachments=args.attach)
     except ValueError as exc:
         logger.error(exc)
-        return
+        raise SystemExit(1) from exc
 
     results = {}
     if args.check_dmarc:

--- a/smtpburst/datagen.py
+++ b/smtpburst/datagen.py
@@ -113,8 +113,8 @@ def generate(
     if isinstance(mode, str):
         try:
             mode = DataMode(mode.lower())
-        except ValueError:
-            mode = DataMode.ASCII
+        except ValueError as exc:
+            raise ValueError(f"invalid data mode: {mode}") from exc
 
     if mode is DataMode.BINARY:
         return gen_binary(size, secure=secure, stream=stream)

--- a/smtpburst/send.py
+++ b/smtpburst/send.py
@@ -60,7 +60,7 @@ def append_message(cfg: Config, attachments: Optional[List[str]] = None) -> byte
 
     rand = datagen.generate(
         cfg.SB_SIZE,
-        mode=datagen.DataMode(cfg.SB_DATA_MODE),
+        mode=cfg.SB_DATA_MODE,
         secure=cfg.SB_SECURE_RANDOM,
         words=cfg.SB_DICT_WORDS,
         repeat=cfg.SB_REPEAT_STRING,

--- a/tests/test_datagen.py
+++ b/tests/test_datagen.py
@@ -22,6 +22,11 @@ def test_generate_negative_size():
         datagen.generate(-1)
 
 
+def test_generate_invalid_mode():
+    with pytest.raises(ValueError, match="invalid data mode"):
+        datagen.generate(10, mode="bogus")
+
+
 def test_gen_binary_stream_partial(monkeypatch):
     class PartialStream:
         def __init__(self, chunks):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,7 @@ from smtpburst import __main__ as main_mod
 from smtpburst import send
 from smtpburst import pipeline
 import logging
+import pytest
 
 
 def test_main_open_sockets(monkeypatch):
@@ -275,3 +276,15 @@ def test_report_file(monkeypatch, tmp_path):
 
     expected = main_mod.ascii_report({"ping": "pong"})
     assert out_file.read_text() == expected
+
+
+def test_main_exits_on_error(monkeypatch):
+    def bad_bomb(cfg, attachments=None):
+        raise ValueError("bad mode")
+
+    monkeypatch.setattr(send, "bombing_mode", bad_bomb)
+
+    with pytest.raises(SystemExit) as excinfo:
+        main_mod.main([])
+
+    assert excinfo.value.code == 1


### PR DESCRIPTION
## Summary
- Validate `generate` mode values and raise `ValueError` for unknown data modes
- Pass string data mode from `send` to `generate` and report mode errors in CLI entrypoint
- Test that invalid data mode strings trigger a `ValueError`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b72f3f8c1883259f1345b21db7914f