### PR TITLE
Propagate send failures via non-zero CLI exit

### DIFF
--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -127,7 +127,7 @@ def main(argv=None):
             send.bombing_mode(cfg, attachments=args.attach)
     except ValueError as exc:
         logger.error(exc)
-        return
+        raise SystemExit(1) from exc
 
     results = {}
     if args.check_dmarc:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,7 @@ from smtpburst import __main__ as main_mod
 from smtpburst import send
 from smtpburst import pipeline
 import logging
+import pytest
 
 
 def test_main_open_sockets(monkeypatch):
@@ -275,3 +276,15 @@ def test_report_file(monkeypatch, tmp_path):
 
     expected = main_mod.ascii_report({"ping": "pong"})
     assert out_file.read_text() == expected
+
+
+def test_main_exits_on_error(monkeypatch):
+    def bad_bomb(cfg, attachments=None):
+        raise ValueError("bad mode")
+
+    monkeypatch.setattr(send, "bombing_mode", bad_bomb)
+
+    with pytest.raises(SystemExit) as excinfo:
+        main_mod.main([])
+
+    assert excinfo.value.code == 1


### PR DESCRIPTION
## Summary
- Raise `SystemExit(1)` after logging `ValueError` in CLI entrypoint
- Add regression test ensuring `main` exits non-zero on send failure

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7330998a4832595e759ba290ff758