### PR TITLE
Refine CI with separate formatting, linting, and testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,35 @@ on:
   pull_request:
 
 jobs:
-  build:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Check formatting
+        run: black --check .
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Run flake8
+        run: flake8
+
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -18,12 +46,22 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
           pip install -e .
-      - name: Check formatting
-        run: black --check .
-      - name: Run flake8
-        run: flake8
       - name: Run tests
         run: pytest
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [format, lint, test]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install -e .
       - name: Build wheel and sdist
         run: python -m build
       - name: Check package

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS
+
+This repository uses a consistent workflow:
+
+- Format code with `black` using the default configuration.
+- Lint with `flake8` and respect the settings in `setup.cfg`.
+- Run the test suite with `pytest`.
+
+All pull requests must run and pass these checks locally before submission.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,12 @@
+# Project Specification
+
+`smtp-burst` sends bursts of SMTP emails for testing.  Development targets
+Python 3.11.
+
+## Development Requirements
+
+Ensure the following commands succeed before submitting changes:
+
+- `black --check .`
+- `flake8`
+- `pytest`

--- a/smtpburst/__main__.py
+++ b/smtpburst/__main__.py
@@ -186,9 +186,7 @@ def main(argv=None):
         results["open_relay"] = nettests.open_relay_test(host, port)
     if args.ping_test:
         try:
-            results["ping"] = nettests.ping(
-                args.ping_test, timeout=args.ping_timeout
-            )
+            results["ping"] = nettests.ping(args.ping_test, timeout=args.ping_timeout)
         except nettests.CommandNotFoundError as exc:
             results["ping"] = str(exc)
     if args.traceroute_test:

--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -34,7 +34,10 @@ CLI_OPTIONS: Iterable[CLIOption] = [
         ("--server",),
         {"default_attr": "SB_SERVER", "help": "SMTP server to connect to"},
     ),
-    (("--helo-host",), {"default_attr": "SB_HELO_HOST", "help": "Host to use in EHLO/HELO"}),
+    (
+        ("--helo-host",),
+        {"default_attr": "SB_HELO_HOST", "help": "Host to use in EHLO/HELO"},
+    ),
     (("--sender",), {"default_attr": "SB_SENDER", "help": "Envelope sender address"}),
     (
         ("--receivers",),

--- a/tests/test_banner.py
+++ b/tests/test_banner.py
@@ -73,7 +73,9 @@ def test_main_banner_check_report(monkeypatch):
 
     monkeypatch.setattr(main_mod.discovery, "banner_check", fake_banner_check)
     monkeypatch.setattr(main_mod, "ascii_report", fake_report)
-    monkeypatch.setattr(main_mod.send, "bombing_mode", lambda cfg, attachments=None: None)
+    monkeypatch.setattr(
+        main_mod.send, "bombing_mode", lambda cfg, attachments=None: None
+    )
 
     main_mod.main(["--banner-check", "--server", "srv"])
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -166,7 +166,9 @@ def test_main_tls_discovery(monkeypatch):
     monkeypatch.setattr(main_mod.send, "parse_server", lambda s: ("h", 443))
     monkeypatch.setattr("smtpburst.tlstest.test_versions", fake_test)
     monkeypatch.setattr(main_mod, "ascii_report", fake_report)
-    monkeypatch.setattr(main_mod.send, "bombing_mode", lambda cfg, attachments=None: None)
+    monkeypatch.setattr(
+        main_mod.send, "bombing_mode", lambda cfg, attachments=None: None
+    )
 
     main_mod.main(["--tls-discovery", "h"])
 
@@ -187,7 +189,9 @@ def test_main_banner_check(monkeypatch):
 
     monkeypatch.setattr(main_mod.discovery, "banner_check", fake_banner_check)
     monkeypatch.setattr(main_mod, "ascii_report", fake_report)
-    monkeypatch.setattr(main_mod.send, "bombing_mode", lambda cfg, attachments=None: None)
+    monkeypatch.setattr(
+        main_mod.send, "bombing_mode", lambda cfg, attachments=None: None
+    )
 
     main_mod.main(["--banner-check", "--server", "srv"])
 
@@ -208,7 +212,9 @@ def test_main_rdns_test(monkeypatch):
 
     monkeypatch.setattr(main_mod.discovery.rdns, "verify", fake_verify)
     monkeypatch.setattr(main_mod, "ascii_report", fake_report)
-    monkeypatch.setattr(main_mod.send, "bombing_mode", lambda cfg, attachments=None: None)
+    monkeypatch.setattr(
+        main_mod.send, "bombing_mode", lambda cfg, attachments=None: None
+    )
 
     main_mod.main(["--rdns-test", "--server", "host"])
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -155,11 +155,15 @@ def test_check_proxy_failure(monkeypatch, caplog):
 @pytest.mark.parametrize("case", ["missing", "timeout"])
 def test_check_proxy_ping_errors(monkeypatch, caplog, case):
     if case == "missing":
+
         def fake_ping(host):
             raise nettests.CommandNotFoundError("ping")
+
     else:
+
         def fake_ping(host):
             return "ping command timed out"
+
     monkeypatch.setattr(proxy, "ping", fake_ping)
     with caplog.at_level(logging.WARNING):
         assert not proxy.check_proxy("bad:1")


### PR DESCRIPTION
## Summary
- split CI into discrete `format`, `lint`, `test`, and `build` jobs
- document required checks in new `SPEC.md` and `AGENTS.md`
- format project with Black to satisfy flake8 line-length

## Testing
- `black --check .`
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b885d0838083259fec1966f52a40b7