### PR TITLE
Align ASCII report output

### DIFF
--- a/smtpburst/reporting/__init__.py
+++ b/smtpburst/reporting/__init__.py
@@ -15,12 +15,12 @@ def ascii_report(results: Dict[str, Any]) -> str:
     """Return simple ASCII formatted report from ``results``."""
 
     width = max([len(k) for k in results] + [len("Test Report")])
-    border = "+" + "-" * (width + 2) + "+"
-    header = "| " + "Test Report" + " " * (width - len("Test Report")) + " |"
+    border = "+" + "-" * (width + 4) + "+"
+    header = f"| {'Test Report':<{width + 2}} |"
 
     lines = [border, header, border]
     for name, data in results.items():
-        lines.append(f"{name:<{width}}: {data}")
+        lines.append(f"| {name:<{width}} | {data}")
     lines.append(border)
     return "\n".join(lines)
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -15,15 +15,15 @@ def test_ascii_report_long_keys():
     lines = report.splitlines()
 
     width = len("this_is_a_really_long_key")
-    border = "+" + "-" * (width + 2) + "+"
-    header = "| Test Report" + " " * (width - len("Test Report")) + " |"
+    border = "+" + "-" * (width + 4) + "+"
+    header = f"| {'Test Report':<{width + 2}} |"
 
     assert lines[0] == border
     assert lines[1] == header
     assert lines[2] == border
     assert lines[-1] == border
-    assert lines[3] == f"short{' ' * (width - len('short'))}: 1"
-    assert lines[4] == "this_is_a_really_long_key: 2"
+    assert lines[3] == f"| {'short':<{width}} | 1"
+    assert lines[4] == f"| {'this_is_a_really_long_key':<{width}} | 2"
 
 
 def test_json_report_valid():


### PR DESCRIPTION
## Summary
- format ASCII report rows with pipe separators to align with headers
- expand table border width to include separator columns
- update tests for new ASCII report layout

## Testing
- `flake8 smtpburst/reporting/__init__.py tests/test_reporting.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9fee07c0483258f70c3cd53a8ea77