### PR TITLE
Raise structured errors for network tests

### DIFF
--- a/smtpburst/discovery/nettests.py
+++ b/smtpburst/discovery/nettests.py
@@ -19,7 +19,7 @@ class CommandNotFoundError(Exception):
         self.cmd = cmd
 
 
-def ping(host: str, count: int = 1, timeout: int = 1) -> str:
+def ping(host: str, count: int = 1, timeout: int = 1) -> str | Dict[str, str]:
     """Return output of ``ping`` command for ``host``.
 
     Raises:
@@ -59,12 +59,12 @@ def ping(host: str, count: int = 1, timeout: int = 1) -> str:
             return proc.stdout.strip()
         return ""
     except subprocess.TimeoutExpired:  # pragma: no cover - depends on runtime
-        return f"{cmd[0]} command timed out"
+        return {"error": "timeout", "cmd": cmd[0]}
     except Exception as exc:  # pragma: no cover - other errors
-        return str(exc)
+        return {"error": str(exc), "cmd": cmd[0]}
 
 
-def traceroute(host: str, count: int = 30, timeout: int = 5) -> str:
+def traceroute(host: str, count: int = 30, timeout: int = 5) -> str | Dict[str, str]:
     """Return output of ``traceroute`` command for ``host``.
 
     Raises:
@@ -92,9 +92,9 @@ def traceroute(host: str, count: int = 30, timeout: int = 5) -> str:
         )
         return proc.stdout.strip()
     except subprocess.TimeoutExpired:  # pragma: no cover - depends on runtime
-        return f"{cmd[0]} command timed out"
+        return {"error": "timeout", "cmd": cmd[0]}
     except Exception as exc:  # pragma: no cover - other errors
-        return str(exc)
+        return {"error": str(exc), "cmd": cmd[0]}
 
 
 def open_relay_test(host: str, port: int = 25) -> bool:

--- a/smtpburst/proxy.py
+++ b/smtpburst/proxy.py
@@ -69,7 +69,10 @@ def check_proxy(
     except CommandNotFoundError:
         logger.warning("Ping to proxy %s failed", proxy)
         return None
-    if not result or "timed out" in result.lower():
+    if isinstance(result, dict):
+        logger.warning("Ping to proxy %s failed: %s", proxy, result.get("error"))
+        return None
+    if not result:
         logger.warning("Ping to proxy %s failed", proxy)
         return None
 

--- a/tests/test_nettests_timeout.py
+++ b/tests/test_nettests_timeout.py
@@ -11,7 +11,10 @@ def test_ping_timeout(monkeypatch):
         raise subprocess.TimeoutExpired(cmd, timeout)
 
     monkeypatch.setattr(nettests.subprocess, "run", fake_run)
-    assert nettests.ping("host", timeout=2) == "ping command timed out"
+    assert nettests.ping("host", timeout=2) == {
+        "error": "timeout",
+        "cmd": "ping",
+    }
 
 
 def test_traceroute_timeout(monkeypatch):
@@ -22,7 +25,10 @@ def test_traceroute_timeout(monkeypatch):
         raise subprocess.TimeoutExpired(cmd, timeout)
 
     monkeypatch.setattr(nettests.subprocess, "run", fake_run)
-    assert nettests.traceroute("host", timeout=2) == "traceroute command timed out"
+    assert nettests.traceroute("host", timeout=2) == {
+        "error": "timeout",
+        "cmd": "traceroute",
+    }
 
 
 def test_ping_ipv6_prefers_ping6(monkeypatch):

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -162,7 +162,7 @@ def test_check_proxy_ping_errors(monkeypatch, caplog, case):
     else:
 
         def fake_ping(host):
-            return "ping command timed out"
+            return {"error": "timeout", "cmd": "ping"}
 
     monkeypatch.setattr(proxy, "ping", fake_ping)
     with caplog.at_level(logging.WARNING):


### PR DESCRIPTION
## Summary
- return structured dicts for ping/traceroute timeouts and execution errors
- log structured ping failures in proxy checker
- update tests for new error handling

## Testing
- `black smtpburst/discovery/nettests.py smtpburst/proxy.py tests/test_nettests_timeout.py tests/test_proxy.py`
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb3735c1508325b0bb10dd2caf97dd