### PR TITLE
Use POP3 STAT for message count

### DIFF
--- a/smtpburst/inbox/__init__.py
+++ b/smtpburst/inbox/__init__.py
@@ -46,6 +46,8 @@ def pop3_search(
         pop.user(user)
         pop.pass_(password)
         ids: List[int] = []
+        # ``stat`` provides the message count without fetching all IDs as
+        # ``list`` would, making large mailboxes more efficient to scan.
         count, _ = pop.stat()
         for i in range(1, count + 1):
             resp, lines, _ = pop.retr(i)


### PR DESCRIPTION
## Summary
- document `stat` usage in POP3 inbox search
- expand POP3 inbox tests for large mailbox counts
- align error case test with `stat`

## Testing
- `black smtpburst/inbox/__init__.py tests/test_inbox.py`
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be9bd8e738832588648f6e171968b5