### PR TITLE
Ensure CLI numeric options are positive

### DIFF
--- a/smtpburst/cli.py
+++ b/smtpburst/cli.py
@@ -13,6 +13,23 @@ try:
 except ImportError:  # pragma: no cover - library may not be installed
     yaml = None
 
+
+def positive_int(value: str) -> int:
+    """Return int from *value* ensuring it is positive."""
+    ivalue = int(value)
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError("value must be > 0")
+    return ivalue
+
+
+def positive_float(value: str) -> float:
+    """Return float from *value* ensuring it is positive."""
+    fvalue = float(value)
+    if fvalue <= 0:
+        raise argparse.ArgumentTypeError("value must be > 0")
+    return fvalue
+
+
 CLIOption = Tuple[Tuple[str, ...], Dict[str, Any]]
 
 # Each tuple contains positional flags and argument keyword options.  Any entry
@@ -61,7 +78,7 @@ CLI_OPTIONS: Iterable[CLIOption] = [
     (
         ("--emails-per-burst",),
         {
-            "type": int,
+            "type": positive_int,
             "default_attr": "SB_SGEMAILS",
             "help": "Number of emails per burst",
         },
@@ -69,7 +86,7 @@ CLI_OPTIONS: Iterable[CLIOption] = [
     (
         ("--bursts",),
         {
-            "type": int,
+            "type": positive_int,
             "default_attr": "SB_BURSTS",
             "help": "Number of bursts to send",
         },
@@ -77,7 +94,7 @@ CLI_OPTIONS: Iterable[CLIOption] = [
     (
         ("--email-delay",),
         {
-            "type": float,
+            "type": positive_float,
             "default_attr": "SB_SGEMAILSPSEC",
             "help": "Delay in seconds between individual emails",
         },
@@ -85,7 +102,7 @@ CLI_OPTIONS: Iterable[CLIOption] = [
     (
         ("--burst-delay",),
         {
-            "type": float,
+            "type": positive_float,
             "default_attr": "SB_BURSTSPSEC",
             "help": "Delay in seconds between bursts",
         },
@@ -93,7 +110,7 @@ CLI_OPTIONS: Iterable[CLIOption] = [
     (
         ("--global-delay",),
         {
-            "type": float,
+            "type": positive_float,
             "default_attr": "SB_GLOBAL_DELAY",
             "help": "Delay applied before any network action",
         },
@@ -101,7 +118,7 @@ CLI_OPTIONS: Iterable[CLIOption] = [
     (
         ("--socket-delay",),
         {
-            "type": float,
+            "type": positive_float,
             "default_attr": "SB_OPEN_SOCKETS_DELAY",
             "help": "Delay between open socket checks",
         },
@@ -109,7 +126,7 @@ CLI_OPTIONS: Iterable[CLIOption] = [
     (
         ("--tarpit-threshold",),
         {
-            "type": float,
+            "type": positive_float,
             "default_attr": "SB_TARPIT_THRESHOLD",
             "help": "Latency in seconds considered a tarpit",
         },
@@ -117,7 +134,7 @@ CLI_OPTIONS: Iterable[CLIOption] = [
     (
         ("--timeout",),
         {
-            "type": float,
+            "type": positive_float,
             "default_attr": "SB_TIMEOUT",
             "help": "Timeout in seconds for network operations",
         },
@@ -125,7 +142,7 @@ CLI_OPTIONS: Iterable[CLIOption] = [
     (
         ("--open-sockets",),
         {
-            "type": int,
+            "type": positive_int,
             "default": 0,
             "help": "Open N TCP sockets and hold them open instead of sending email",
         },
@@ -133,21 +150,21 @@ CLI_OPTIONS: Iterable[CLIOption] = [
     (
         ("--socket-duration",),
         {
-            "type": float,
+            "type": positive_float,
             "help": "Close open sockets after SECONDS",
         },
     ),
     (
         ("--socket-iterations",),
         {
-            "type": int,
+            "type": positive_int,
             "help": "Run the socket loop this many times before closing",
         },
     ),
     (
         ("--port",),
         {
-            "type": int,
+            "type": positive_int,
             "default": 25,
             "help": "TCP port to use for socket mode",
         },
@@ -155,7 +172,7 @@ CLI_OPTIONS: Iterable[CLIOption] = [
     (
         ("--size",),
         {
-            "type": int,
+            "type": positive_int,
             "default_attr": "SB_SIZE",
             "help": "Random data size in bytes appended to each message",
         },
@@ -241,7 +258,7 @@ CLI_OPTIONS: Iterable[CLIOption] = [
     (
         ("--stop-fail-count",),
         {
-            "type": int,
+            "type": positive_int,
             "default_attr": "SB_STOPFQNT",
             "help": "Number of failed emails that triggers stopping",
         },
@@ -249,7 +266,7 @@ CLI_OPTIONS: Iterable[CLIOption] = [
     (
         ("--retry-count",),
         {
-            "type": int,
+            "type": positive_int,
             "default_attr": "SB_RETRY_COUNT",
             "help": "Number of times to retry sending after failure",
         },
@@ -274,7 +291,7 @@ CLI_OPTIONS: Iterable[CLIOption] = [
     (
         ("--proxy-timeout",),
         {
-            "type": float,
+            "type": positive_float,
             "default_attr": "SB_PROXY_TIMEOUT",
             "help": "Timeout in seconds when validating proxies",
         },
@@ -390,7 +407,7 @@ CLI_OPTIONS: Iterable[CLIOption] = [
     ),
     (
         ("--ping-timeout",),
-        {"type": int, "default": 1, "help": "Ping timeout in seconds"},
+        {"type": positive_int, "default": 1, "help": "Ping timeout in seconds"},
     ),
     (
         ("--traceroute-test",),
@@ -399,7 +416,7 @@ CLI_OPTIONS: Iterable[CLIOption] = [
     (
         ("--traceroute-timeout",),
         {
-            "type": int,
+            "type": positive_int,
             "default": 5,
             "help": "Traceroute timeout in seconds",
         },

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -60,6 +60,44 @@ def test_socket_iterations_option():
     assert args.socket_iterations == 3
 
 
+@pytest.mark.parametrize(
+    "flag",
+    [
+        "--emails-per-burst",
+        "--bursts",
+        "--open-sockets",
+        "--socket-iterations",
+        "--port",
+        "--size",
+        "--stop-fail-count",
+        "--retry-count",
+        "--ping-timeout",
+        "--traceroute-timeout",
+    ],
+)
+def test_negative_int_options(flag):
+    with pytest.raises(SystemExit):
+        burst_cli.parse_args([flag, "-1"], Config())
+
+
+@pytest.mark.parametrize(
+    "flag",
+    [
+        "--email-delay",
+        "--burst-delay",
+        "--global-delay",
+        "--socket-delay",
+        "--tarpit-threshold",
+        "--timeout",
+        "--socket-duration",
+        "--proxy-timeout",
+    ],
+)
+def test_negative_float_options(flag):
+    with pytest.raises(SystemExit):
+        burst_cli.parse_args([flag, "-0.1"], Config())
+
+
 def test_proxy_file_option(tmp_path):
     proxy_file = tmp_path / "proxies.txt"
     proxy_file.write_text("127.0.0.1:1080\n")


### PR DESCRIPTION
## Summary
- add `positive_int` and `positive_float` helpers to reject non-positive values
- validate burst, socket, and delay CLI options with positive value types
- test that negative CLI inputs raise errors

## Testing
- `flake8 smtpburst/cli.py tests/test_cli_config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c40a0dac788325885ac58ea6242a2b