### PR TITLE
Handle IPv6 literals in proxy parsing

### DIFF
--- a/smtpburst/proxy.py
+++ b/smtpburst/proxy.py
@@ -49,14 +49,16 @@ def parse_proxy(proxy: str) -> ProxyInfo:
         host_part, sep, port_part = netloc.rpartition(":")
         if sep:
             if port_part.isdigit():
+                port_int = int(port_part)
+                if not (0 <= port_int <= 65535):
+                    raise ValueError(f"Invalid port in proxy '{proxy}'")
                 try:
                     host_ip = ipaddress.IPv6Address(host_part)
                 except ipaddress.AddressValueError:
                     pass
                 else:
                     host = str(host_ip)
-                    port = int(port_part)
-                    return ProxyInfo(host, port, username, password)
+                    return ProxyInfo(host, port_int, username, password)
             else:
                 raise ValueError(f"Invalid port in proxy '{proxy}'")
         host_ip = ipaddress.IPv6Address(netloc)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -42,6 +42,15 @@ def test_parse_proxy_ipv6():
     assert info.host == "2001:db8::1" and info.port == 1080
 
 
+def test_parse_proxy_ipv6_unbracketed():
+    info = proxy.parse_proxy("2001:db8::1:8080")
+    assert info.host == "2001:db8::1" and info.port == 8080
+    info = proxy.parse_proxy("2001:db8::1")
+    assert info.host == "2001:db8::1" and info.port == 1080
+    with pytest.raises(ValueError):
+        proxy.parse_proxy("2001:db8::1:70000")
+
+
 def test_invalid_order(tmp_path):
     path = tmp_path / "p.txt"
     path.write_text("a\nb\n")


### PR DESCRIPTION
## Summary
- support IPv6 literals in `parse_proxy`, including `[addr]:port`
- normalize IPv6 addresses returned by `ProxyInfo`
- test proxy parsing with IPv6 examples

## Testing
- `black smtpburst/proxy.py tests/test_proxy.py`
- `flake8 smtpburst/proxy.py tests/test_proxy.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4705e45248325bdc049c56b8ed6e7