### PR TITLE
chore: overwrite coverage badge in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run tests
         run: |
           pytest --cov=smtpburst --cov-report=xml
-          coverage-badge -o coverage.svg
+          coverage-badge -f -o coverage.svg
       - name: Upload coverage badge
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- ensure coverage.svg is overwritten when generating coverage badge

## Testing
- `black --check .`
- `python -m flake8`
- `pytest --cov=smtpburst --cov-report=xml`
- `python -m coverage_badge -f -o coverage.svg`


------
https://chatgpt.com/codex/tasks/task_e_68c548a0dad8832596061f77b2065f06