### PR TITLE
Add release workflow and fix coverage badge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-x64
+            runs-on: ubuntu-latest
+            shell: bash
+            build: bash scripts/build_ubuntu.sh
+            asset: dist/linux/smtp-burst
+          - target: linux-arm64
+            runs-on: [ubuntu-latest, ARM64]
+            shell: bash
+            build: bash scripts/build_ubuntu.sh
+            asset: dist/linux/smtp-burst
+          - target: windows-x64
+            runs-on: windows-latest
+            shell: cmd
+            build: scripts\\build_windows.bat
+            asset: dist\\windows\\smtp-burst.exe
+          - target: macos-x64
+            runs-on: macos-latest
+            shell: bash
+            build: bash scripts/build_macos.sh
+            asset: dist/macos/smtp-burst
+          - target: macos-arm64
+            runs-on: macos-14
+            shell: bash
+            build: bash scripts/build_macos.sh
+            asset: dist/macos/smtp-burst
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Build binary
+        run: ${{ matrix.build }}
+        shell: ${{ matrix.shell }}
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ matrix.asset }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # smtp-burst
 
 [![CI](https://github.com/supermarsx/smtp-burst/actions/workflows/ci.yml/badge.svg)](https://github.com/supermarsx/smtp-burst/actions/workflows/ci.yml)
-![Coverage](https://raw.githubusercontent.com/supermarsx/smtp-burst/main/coverage.svg)
+![Coverage](coverage.svg)
 ![Downloads](https://img.shields.io/github/downloads/supermarsx/smtp-burst/total)
 ![Stars](https://img.shields.io/github/stars/supermarsx/smtp-burst)
 ![Forks](https://img.shields.io/github/forks/supermarsx/smtp-burst)


### PR DESCRIPTION
## Summary
- build and upload binaries for Windows, Linux (x64/arm64), and macOS (x64/arm64) on tag pushes
- show coverage badge from repository asset

## Testing
- `black .`
- `flake8`
- `pytest --cov=smtpburst --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_68c69d903e648325a1679cb45c0ba7dd